### PR TITLE
fixed non proxy hosts

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/providers/RequestManager.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/RequestManager.java
@@ -17,16 +17,23 @@
 
 package fr.cnes.sonar.report.providers;
 
-import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
-import fr.cnes.sonar.report.exceptions.SonarQubeException;
-import fr.cnes.sonar.report.utils.StringManager;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.sonarqube.ws.client.GetRequest;
 import org.sonarqube.ws.client.HttpConnector;
 import org.sonarqube.ws.client.WsResponse;
 
-import java.net.InetSocketAddress;
-import java.net.Proxy;
+import com.google.common.collect.Sets;
+
+import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
+import fr.cnes.sonar.report.exceptions.SonarQubeException;
+import fr.cnes.sonar.report.utils.StringManager;
 
 /**
  * Manage http requests.
@@ -57,6 +64,11 @@ public final class RequestManager {
      */
     public static final String STR_PROXY_PASS = "https.proxyPassword";
 
+    /**
+     * System property for non proxy hosts
+     */
+    public static final String STR_NON_PROXY_HOSTS = "http.nonProxyHosts";
+    
     public static final String QUERY_CHAR = "?";
     public static final String ANCHOR_CHAR = "#";
 
@@ -111,6 +123,7 @@ public final class RequestManager {
         final String proxyPort = System.getProperty(STR_PROXY_PORT, StringManager.EMPTY);
         final String proxyUser = System.getProperty(STR_PROXY_USER, StringManager.EMPTY);
         final String proxyPass = System.getProperty(STR_PROXY_PASS, StringManager.EMPTY);
+        final String nonProxyHosts = System.getProperty(STR_NON_PROXY_HOSTS, StringManager.EMPTY);
 
         // Initialize http connector builder.
         final HttpConnector.Builder builder = HttpConnector.newBuilder()
@@ -123,7 +136,7 @@ public final class RequestManager {
         }
 
         // Set proxy settings.
-        if(!proxyHost.isEmpty()) {
+        if(!proxyHost.isEmpty() && !avoidProxy(nonProxyHosts, baseUrl)) {
             int proxyUsedPort;
             try {
                 proxyUsedPort = Integer.valueOf(proxyPort);
@@ -163,4 +176,50 @@ public final class RequestManager {
 
         return response.content();
     }
+    
+    /**
+     * Validate if should avoid proxy
+     * @param nonProxyHosts non proxy hosts according to http.nonProxyHost property, example: localhost|127.*|[::1]
+     * @param url	url as String
+     * @return indicates whether to avoid proxy usage
+     * @throws SonarQubeException When cannot parse url to URI
+     */
+    private boolean avoidProxy(String nonProxyHosts, String url) throws SonarQubeException {
+        
+    	if(url == null || url.isEmpty())
+    		return false;
+
+    	String strUriHost;
+    	
+   		try {
+			strUriHost = new URI(url).getHost();
+		} catch (URISyntaxException e) {
+            throw new SonarQubeException("Impossible parse url to URI.", e);
+		}
+    	
+        String regex = Sets.newHashSet(nonProxyHosts.split("\\|"))
+        	.stream()
+        	.filter(nps -> !nps.isEmpty())
+        	.map(this::disjunctToRegex).collect(Collectors.joining("|"));
+    	
+        Pattern pattern = Pattern.compile(regex);
+        
+        return pattern != null && pattern.matcher(strUriHost).matches();
+        
+    }
+    
+    private String disjunctToRegex(String disjunct) {
+        String regex;
+        if (disjunct.startsWith("*") && disjunct.endsWith("*")) {
+            regex = ".*" + Pattern.quote(disjunct.substring(1, disjunct.length() - 1)) + ".*";
+        } else if (disjunct.startsWith("*")) {
+            regex = ".*" + Pattern.quote(disjunct.substring(1));
+        } else if (disjunct.endsWith("*")) {
+            regex = Pattern.quote(disjunct.substring(0, disjunct.length() - 1)) + ".*";
+        } else {
+            regex = Pattern.quote(disjunct);
+        }
+        return regex;
+    }
+    
 }


### PR DESCRIPTION
# Fixed issues
* Fix #
* Fix # solution when setting up a proxy

# Proposed changes
* The problem to be solve occurs when using a proxy in sonar settings, as described below.
•	The following properties are configured in the sonar.properties file:
o	http.proxyHost
o	http.proxyPort
o	http.proxyUser
o	http.proxyPassword
o	https.proxyHost
o	https.proxyPort
o	https.proxyUser
o	https.proxyPassword
o	http.nonProxyHosts
•	when tried to generate the report, on the sonar website you see the following error: “{” errors “: [{”msg“:”An error has occurred. Please contact your administrator “}]}”, after reviewing the sonar logs, it was found that the plugin makes a request to the same sonar server verifying that it is online, but ignores the property http.nonProxyHosts passing this request through the proxy.
•	The problem in the plugin code was reviewed and it was detected that the property is not being used http.nonProxyHosts, therefore the modification is made as follows:
o	only the class fr.cnes.sonar.report.providers.RequestManager is modified.
o	In the get method:
	property http. nonProxyHosts search added
	validation is added to consider the http.nonProxyHosts property with a method created (avoidProxy) and decide whether to use the proxy.
o	avoidProxy added method: the method was created in order to validate the added hosts in property http.nonProxyHosts and prevent internal requests from being made with the proxy.
o	disjunctToRegex added method: this method is added directly from openjdk 11 since java version 8 does not work for all cases and this may vary depending on the operating system.
•	NOTE : For this to work, the proxy must be defined in the https properties.

