### PR TITLE
Remove deprecated classloader option inside pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.test>src/test/java</sonar.test>
         <sonar.skipDependenciesPackaging>true</sonar.skipDependenciesPackaging>
-        <sonar.useChildFirstClassLoader>true</sonar.useChildFirstClassLoader>
         <sonar.pluginClass>fr.cnes.sonar.plugin.ReportSonarPlugin</sonar.pluginClass>
         <app.mainClass>fr.cnes.sonar.report.ReportCommandLine</app.mainClass>
     </properties>


### PR DESCRIPTION
Simply removing the deprecated classloader option.
The tool seems to work seemlessly for me, but I don't remember exactly why put this in the first place.
@begarco : could you remind me this ? So I can make sure it works perfectly without this directive.

# Fixed issues
* Fix #92 
* Fix #136 