### PR TITLE
Feature/support special chars qp

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/providers/QualityProfileProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/QualityProfileProvider.java
@@ -67,18 +67,13 @@ public class QualityProfileProvider extends AbstractDataProvider {
                 jo.get(PROFILES), ProfileMetaData[].class));
         for (ProfileMetaData profileMetaData : metaData) {
             final ProfileData profileData = new ProfileData();
-
-            // URL Encode Quality Profile & Language name to avoid issue with special characters
-            profileMetaData.setLanguage(
-                UrlEncoder.urlEncodeString(profileMetaData.getLanguage()));
-            profileMetaData.setName(
-                UrlEncoder.urlEncodeString(profileMetaData.getName()));
             
             // get configuration
+            // URL Encode Quality Profile & Language name to avoid issue with special characters
             request = String.format(getRequest(GET_QUALITY_PROFILES_CONF_REQUEST),
                     getServer().getUrl(),
-                    profileMetaData.getLanguage(),
-                    profileMetaData.getName());
+                    UrlEncoder.urlEncodeString(profileMetaData.getLanguage()),
+                    UrlEncoder.urlEncodeString(profileMetaData.getName()));
             // perform request to sonarqube server
             final String xml = stringRequest(request);
             // add configuration as string to the profile

--- a/src/main/java/fr/cnes/sonar/report/providers/QualityProfileProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/QualityProfileProvider.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import fr.cnes.sonar.report.utils.UrlEncoder;
+
 /**
  * Provides quality gates
  */
@@ -65,13 +67,18 @@ public class QualityProfileProvider extends AbstractDataProvider {
                 jo.get(PROFILES), ProfileMetaData[].class));
         for (ProfileMetaData profileMetaData : metaData) {
             final ProfileData profileData = new ProfileData();
+
+            // URL Encode Quality Profile & Language name to avoid issue with special characters
+            profileMetaData.setLanguage(
+                UrlEncoder.urlEncodeString(profileMetaData.getLanguage()));
+            profileMetaData.setName(
+                UrlEncoder.urlEncodeString(profileMetaData.getName()));
+            
             // get configuration
             request = String.format(getRequest(GET_QUALITY_PROFILES_CONF_REQUEST),
                     getServer().getUrl(),
-                    profileMetaData.getLanguage().replaceAll(String.valueOf(StringManager.SPACE),
-                    StringManager.URI_SPACE),
-                    profileMetaData.getName().replaceAll(String.valueOf(StringManager.SPACE),
-                    StringManager.URI_SPACE));
+                    profileMetaData.getLanguage(),
+                    profileMetaData.getName());
             // perform request to sonarqube server
             final String xml = stringRequest(request);
             // add configuration as string to the profile

--- a/src/main/java/fr/cnes/sonar/report/utils/UrlEncoder.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/UrlEncoder.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of cnesreport.
+ *
+ * cnesreport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cnesreport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cnesreport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.cnes.sonar.report.utils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Provides methods to encode strings in URL
+ */
+public class UrlEncoder {
+
+    private UrlEncoder() {}
+
+    /**
+     * Logger for the class
+     */
+    protected static final Logger LOGGER = Logger.getLogger(UrlEncoder.class.getCanonicalName());
+
+    /**
+     * URL Encode a string to use with SonarQube API
+     * @param pString String to encode
+     * @return The URL encoded string
+     */
+    public static String urlEncodeString(String pString) {
+        String encodedString = pString;
+
+        try {
+            // URL Encode the String to avoid errors with special characters in URL
+            encodedString = URLEncoder.encode(pString, StandardCharsets.UTF_8.toString());
+            /**
+             * URLEncoder replace whitespaces with + to match HTML convention
+             * So to avoid issues we replace the + with %20
+             * as the + that may have been present in the initial string are now already encoded
+             */ 
+            encodedString = encodedString.replace("+", "%20");
+        } catch(UnsupportedEncodingException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
+        
+        return encodedString;
+    }
+    
+}

--- a/src/test/ut/java/fr/cnes/sonar/report/utils/UrlEncoderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/utils/UrlEncoderTest.java
@@ -2,7 +2,7 @@ package fr.cnes.sonar.report.utils;
 
 import org.junit.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UrlEncoderTest {
 
@@ -14,7 +14,7 @@ public class UrlEncoderTest {
         String initialString = "Test 4 Q&A ++";
         String expectedResult = "Test%204%20Q%26A%20%2B%2B";
         String urlEncodedString = UrlEncoder.urlEncodeString(initialString);
-        assertTrue(urlEncodedString.equals(expectedResult));
+        assertEquals(urlEncodedString, expectedResult);
     }
 
 }

--- a/src/test/ut/java/fr/cnes/sonar/report/utils/UrlEncoderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/utils/UrlEncoderTest.java
@@ -1,0 +1,20 @@
+package fr.cnes.sonar.report.utils;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UrlEncoderTest {
+
+    /**
+     * Test the encoding process & whitespaces partcular management
+     */
+    @Test
+    public void encodeSpecialCharsAndWhitespace() {
+        String initialString = "Test 4 Q&A ++";
+        String expectedResult = "Test%204%20Q%26A%20%2B%2B";
+        String urlEncodedString = UrlEncoder.urlEncodeString(initialString);
+        assertTrue(urlEncodedString.equals(expectedResult));
+    }
+
+}


### PR DESCRIPTION
Adding an UrlEncoder inside the plugin to manage the Quality Profiles name in API calls.
Might be useful for other APIs as well.

# Fixed issues
* Fix #142 
* Fix #146 
