### PR TITLE
Escape File seperator from the projectId & Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:8-jdk-alpine
+
+ARG JAR_FILE=target/sonar-cnes-report.jar
+
+# cd /usr/local/export
+WORKDIR /usr/local/export
+
+# copy target/sonar-cnes-report.jar /usr/local/export/sonar-report.jar
+COPY ${JAR_FILE} sonar-report.jar
+
+# ENTRYPOINT [ "java", "-jar", "sonar-report.jar" ]

--- a/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
@@ -37,6 +37,9 @@ import java.util.Iterator;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
+import com.google.common.escape.Escaper;
+import com.google.common.escape.Escapers;
+
 public class ReportFactory {
 
     /** Property for the word report filename. */
@@ -94,8 +97,10 @@ public class ReportFactory {
         // Export issues and metrics in report if requested.
         if(configuration.isEnableReport()) {
             // prepare docx report's filename
-            final String docXFilename = formatFilename(REPORT_FILENAME, configuration.getOutput(), model.getProjectName());
-            // export the full docx report
+            final String docXFilename = formatFilename(REPORT_FILENAME, configuration.getOutput(), model.getProjectName()); 
+            // // export the full docx report
+            // File f = new File (docXFilename);
+            // f.getParentFile().mkdirs();
             docXExporter.export(model, docXFilename, configuration.getTemplateReport());
         }
 
@@ -196,7 +201,17 @@ public class ReportFactory {
         return StringManager.getProperty(propertyName)
                 .replaceFirst(BASEDIR, Matcher.quoteReplacement(baseDir))
                 .replace(DATE, new SimpleDateFormat(StringManager.DATE_PATTERN).format(new Date()))
-                .replace(NAME, projectName);
+                .replace(NAME, escapeProjectName(projectName));
+    }
+
+    /**
+     * Escapes the folder seperator from the project name.
+     * @param projectName
+     * @return file seperator (/ or \) escaped project name.
+     */
+    private static CharSequence escapeProjectName(String projectName) {
+        Escaper escaper = Escapers.builder().addEscape(File.separatorChar, "_").build();
+        return escaper.escape(projectName);
     }
 
 }

--- a/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
@@ -99,8 +99,6 @@ public class ReportFactory {
             // prepare docx report's filename
             final String docXFilename = formatFilename(REPORT_FILENAME, configuration.getOutput(), model.getProjectName()); 
             // // export the full docx report
-            // File f = new File (docXFilename);
-            // f.getParentFile().mkdirs();
             docXExporter.export(model, docXFilename, configuration.getTemplateReport());
         }
 


### PR DESCRIPTION
# Fixed issues
* Fix #
* Fix #

# Proposed changes
* 
* 

I have faced an issue while trying to apply the report jar into gitlab-ci. If the sonar projectId contains file separator then IOException thrown. Because FileOutputStream is unable to create missing directories. 

Also added a very simple Dockerfile for further development to get reporter into docker image. 