### PR TITLE
Feature/java 11 for sonarcloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - sonarqube: 8.2-community
 
 script:
-  - IS_JDK_11=$(java -version 2>&1 |grep "^openjdk version \"11\." > /dev/null && echo $?)
+  - IS_JDK_11=$(java -version 2>&1 |grep "^openjdk version \"11\." > /dev/null ; echo $?)
   - if [ $sonarqube != "none" ]; then
       mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package;
       chmod +x src/test/it/run-test.sh;mvn clean package;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
   - sonarqube: 8.2-community
 
 script:
-  - IS_JDK_11=$(java -version 2>&1 |grep "^openjdk version \"11\." > /dev/null ; echo $?)
   - if [ $sonarqube != "none" ]; then
       mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package;
       chmod +x src/test/it/run-test.sh;mvn clean package;
@@ -46,7 +45,7 @@ script:
       mvn sonar:sonar -Dsonar.host.url=http://127.0.0.1:9000 -Dsonar.login=admin -Dsonar.password=admin -Dsonar.organization=default-organization -Dsonar.branch.name= ;
       src/test/it/run-test.sh;
       wget "http://localhost:9000/api/cnesreport/report?key=fr.cnes.sonar%3Acnesreport&author=travis-ci&token=noauth";
-    elif [ "${IS_JDK_11}" = "0" ]; then 
+    elif [ "$TRAVIS_JDK_VERSION" = "openjdk11" ]; then 
       mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,28 +24,30 @@ env:
   - sonarqube: 8.2-community
 
 script:
+  - IS_JDK_11=$(java -version 2>&1 |grep "^openjdk version \"11\." > /dev/null && echo $?)
   - if [ $sonarqube != "none" ]; then
-    mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package;
-    chmod +x src/test/it/run-test.sh;mvn clean package;
-    echo "Starting docker";
-    docker run --name sonarqube_${sonarqube} -d -p 127.0.0.1:9000:9000/tcp sonarqube:${sonarqube};
-    echo "Inject plugin";
-    docker cp target/sonar-cnes-report.jar sonarqube_${sonarqube}:/opt/sonarqube/extensions/plugins/;
-    docker exec -u root sonarqube_${sonarqube} chmod 777 /opt/sonarqube/extensions/plugins/sonar-cnes-report.jar;
-    docker restart sonarqube_${sonarqube};
-    echo "Waiting up to 5 minutes for SonarQube...";
-    counter=0;
-    limit=300;
-    status_sonar=$(curl -s "http://localhost:9000/api/system/status" | grep "\"status\":\"UP\"" > /dev/null; echo $?);
-    while [[ 0 -ne $status_sonar && $counter -le $limit ]]; do
-        sleep 1;
-        counter=$(( $counter + 1 ));
-        status_sonar=$(curl -s "http://localhost:9000/api/system/status" | grep "\"status\":\"UP\"" > /dev/null; echo $?);
-    done;
-    mvn sonar:sonar -Dsonar.host.url=http://127.0.0.1:9000 -Dsonar.login=admin -Dsonar.password=admin -Dsonar.organization=default-organization -Dsonar.branch.name= ;
-    src/test/it/run-test.sh;
-    wget "http://localhost:9000/api/cnesreport/report?key=fr.cnes.sonar%3Acnesreport&author=travis-ci&token=noauth";
-    else mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar;
+      mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package;
+      chmod +x src/test/it/run-test.sh;mvn clean package;
+      echo "Starting docker";
+      docker run --name sonarqube_${sonarqube} -d -p 127.0.0.1:9000:9000/tcp sonarqube:${sonarqube};
+      echo "Inject plugin";
+      docker cp target/sonar-cnes-report.jar sonarqube_${sonarqube}:/opt/sonarqube/extensions/plugins/;
+      docker exec -u root sonarqube_${sonarqube} chmod 777 /opt/sonarqube/extensions/plugins/sonar-cnes-report.jar;
+      docker restart sonarqube_${sonarqube};
+      echo "Waiting up to 5 minutes for SonarQube...";
+      counter=0;
+      limit=300;
+      status_sonar=$(curl -s "http://localhost:9000/api/system/status" | grep "\"status\":\"UP\"" > /dev/null; echo $?);
+      while [[ 0 -ne $status_sonar && $counter -le $limit ]]; do
+          sleep 1;
+          counter=$(( $counter + 1 ));
+          status_sonar=$(curl -s "http://localhost:9000/api/system/status" | grep "\"status\":\"UP\"" > /dev/null; echo $?);
+      done;
+      mvn sonar:sonar -Dsonar.host.url=http://127.0.0.1:9000 -Dsonar.login=admin -Dsonar.password=admin -Dsonar.organization=default-organization -Dsonar.branch.name= ;
+      src/test/it/run-test.sh;
+      wget "http://localhost:9000/api/cnesreport/report?key=fr.cnes.sonar%3Acnesreport&author=travis-ci&token=noauth";
+    elif [ "${IS_JDK_11}" = "0" ]; then 
+      mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar;
     fi
 
 cache:


### PR DESCRIPTION
# Fixed issues
* Fix #182

# Proposed changes
* Use only JDK 11 to run the SonarCloud analysis during CI process