### PR TITLE
fix local SQ URL with sonar.web.context

### DIFF
--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -80,13 +80,14 @@ public class ExportTask implements RequestHandler {
                     request.getParam(PluginStringManager.getProperty("api.report.args.branch"));
 
             // Build SonarQube local URL
-            String port = config.get("sonar.web.port").orElse(PluginStringManager.getProperty("plugin.defaultPort"));
-            String host = String.format(PluginStringManager.getProperty("plugin.defaultHost"), port);
+            String port = config.get("sonar.web.port").orElse("9000");
+            String context = config.get("sonar.web.context").orElse("");
+            String sonarUrl = String.format("http://localhost:%s%s", port, context);
 
             ReportCommandLine.execute(new String[]{
                     "report",
                     "-o", outputDirectory.getAbsolutePath(),
-                    "-s", host,
+                    "-s", sonarUrl,
                     "-p", projectKey,
                     "-b", pBranch.isPresent()?pBranch.getValue(): StringManager.NO_BRANCH,
                     "-a", request.getParam(PluginStringManager.getProperty("api.report.args.author")).getValue(),

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -19,8 +19,6 @@ homepage.url=cnesreport/report
 homepage.name=CNES Report
 
 plugin.since=6.5
-plugin.defaultHost=http://localhost:%s
-plugin.defaultPort=9000
 
 api.url=api/cnesreport
 api.description=Export a report in zip file.


### PR DESCRIPTION
## Proposed changes

Fix the local SonarQube URL used for generating the report, when `sonar.web.context` is defined (ie., when SQ is not deployed on the root context).

Without this patch, `http://localhost:9000` would be used (or the same with a different port), but we set `sonar.web.context=/sonar`, meaning the local URL for us is `http://localhost:9000/sonar`.

This follows #148 / #152: before this change, it's the server public URL which was used (`sonar.core.serverBaseURL`, which would have been `http://something/sonar` in our case), instead of the local one, so this plugin was working fine (I think).

## Types of changes

What types of changes does your code introduce to this software?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
