### PR TITLE
Bugfix date argument not working (#192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Generate editable reports for SonarQube projects.
  -a,--author <arg>                 Name of the report writer.
  -b,--branch <arg>                 Branch of the targeted project. Requires Developer Edition or sonarqube-community-branch-plugin. Default: usage of main branch.
  -c,--disable-conf                 Disable export of quality configuration used during analysis.
- -d,--date <arg>                   Date for the report. Default: current date.
+ -d,--date <arg>                   Date for the report. Format: yyyy-MM-dd. Default: current date.
  -e,--disable-spreadsheet          Disable spreadsheet generation.
  -f,--disable-csv                  Disable csv generation.
  -h,--help                         Display this message.

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -39,6 +39,7 @@ import org.sonar.api.utils.text.JsonWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.text.ParseException;
 
 public class ExportTask implements RequestHandler {
 
@@ -60,7 +61,7 @@ public class ExportTask implements RequestHandler {
      */
     @Override
     public void handle(Request request, Response response) throws BadExportationDataTypeException, IOException,
-            UnknownQualityGateException, OpenXML4JException, XmlException, SonarQubeException{
+            UnknownQualityGateException, OpenXML4JException, XmlException, SonarQubeException, ParseException {
 
         // Get project key
         String projectKey = request.getParam(PluginStringManager.getProperty("api.report.args.key")).getValue();
@@ -94,7 +95,7 @@ public class ExportTask implements RequestHandler {
             });
 
             stream.setMediaType("application/zip");
-            String filename = ReportFactory.formatFilename("zip.report.output", "", projectKey);
+            String filename = ReportFactory.formatFilename("zip.report.output", "", "", projectKey);
             response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + '"');
 
 

--- a/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
+++ b/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
@@ -34,6 +34,7 @@ import org.apache.xmlbeans.XmlException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.ParseException;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -78,7 +79,7 @@ public final class ReportCommandLine {
 
         } catch (BadExportationDataTypeException | BadSonarQubeRequestException | IOException |
                 UnknownQualityGateException | OpenXML4JException | XmlException | SonarQubeException |
-                IllegalStateException | IllegalArgumentException e) {
+                IllegalStateException | IllegalArgumentException | ParseException e) {
             // it logs all the stack trace
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             System.exit(-1);
@@ -86,7 +87,7 @@ public final class ReportCommandLine {
     }
 
     public static void execute(final String[] args) throws BadExportationDataTypeException , BadSonarQubeRequestException , IOException,
-    UnknownQualityGateException, OpenXML4JException, XmlException, SonarQubeException{
+    UnknownQualityGateException, OpenXML4JException, XmlException, SonarQubeException, ParseException {
         // Log message.
         String message;
 

--- a/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
@@ -194,6 +194,8 @@ public class ReportFactory {
      * Format a given filename pattern.
      * Add the date and the project's name
      * @param propertyName Name of pattern's property
+     * @param baseDir Path to the folder where to save the file
+     * @param projectDate Date of the current project
      * @param projectName Name of the current project
      * @return a formatted filename
      */
@@ -201,12 +203,15 @@ public class ReportFactory {
             throws ParseException {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(StringManager.DATE_PATTERN);
         String dateStr;
+        // put the current date if no date is given
         if (projectDate.isEmpty()) {
             dateStr = simpleDateFormat.format(new Date());
         } else {
-            if (!projectDate.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}")) {
+            // accept only the defined format
+            if (!projectDate.matches(StringManager.DATE_REGEX)) {
                 throw new IllegalArgumentException("Please provide a date that respects " + StringManager.DATE_PATTERN + " format.");
             }
+            // reject inconsistent dates
             simpleDateFormat.setLenient(false);
             try {
                 dateStr = simpleDateFormat.format(simpleDateFormat.parse(projectDate));

--- a/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
@@ -204,7 +204,15 @@ public class ReportFactory {
         if (projectDate.isEmpty()) {
             dateStr = simpleDateFormat.format(new Date());
         } else {
-            dateStr = simpleDateFormat.format(simpleDateFormat.parse(projectDate));
+            if (!projectDate.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}")) {
+                throw new IllegalArgumentException("Please provide a date that respects " + StringManager.DATE_PATTERN + " format.");
+            }
+            simpleDateFormat.setLenient(false);
+            try {
+                dateStr = simpleDateFormat.format(simpleDateFormat.parse(projectDate));
+            } catch (ParseException e) {
+                throw new ParseException("Invalid date value: day or month exceeds its bounds.", e.getErrorOffset());
+            }
         }
         // construct the filename by replacing date and name
         return StringManager.getProperty(propertyName)

--- a/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
@@ -51,7 +51,7 @@ public class CommandLineManager {
             {"o", "output", Boolean.TRUE.toString(), "Output path for exported resources."},
             {"l", "language", Boolean.TRUE.toString(), "Language of the report. Values: en_US, fr_FR. Default: en_US."},
             {"a", "author", Boolean.TRUE.toString(), "Name of the report writer."},
-            {"d", "date", Boolean.TRUE.toString(), "Date for the report. Default: current date."},
+            {"d", "date", Boolean.TRUE.toString(), "Date for the report. Format: " + StringManager.DATE_PATTERN + ". Default: current date."},
             {"c", "disable-conf", Boolean.FALSE.toString(), "Disable export of quality configuration used during analysis."},
             {"w", "disable-report", Boolean.FALSE.toString(), "Disable report generation."},
             {"e", "disable-spreadsheet", Boolean.FALSE.toString(), "Disable spreadsheet generation."},

--- a/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
@@ -52,6 +52,8 @@ public final class StringManager {
     public static final String ISSUES_OVERFLOW_MSG = "log.overflow.msg";
     /** Pattern to format the date. */
     public static final String DATE_PATTERN = "yyyy-MM-dd";
+    /** Regular expression to match exactly the date format */
+    public static final String DATE_REGEX = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
     /** Default path to the target diretory for report files. */
     public static final String DEFAULT_OUTPUT = "report.path";
     /** Default language for the report. */

--- a/src/test/ut/java/fr/cnes/sonar/report/CommonTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/CommonTest.java
@@ -23,6 +23,7 @@ import fr.cnes.sonar.report.utils.StringManager;
 import org.junit.Before;
 
 import java.util.*;
+import java.text.SimpleDateFormat;
 
 /**
  * Contains common code for report
@@ -69,7 +70,7 @@ public abstract class CommonTest {
                 "-p", PROJECT_KEY,
                 "-a", "Lequal",
                 "-b", BRANCH,
-                "-d", new Date().toString(),
+                "-d", new SimpleDateFormat(StringManager.DATE_PATTERN).format(new Date()),
                 "-o", "./target",
                 "-l", "en_US",
                 "-r", "src/main/resources/template/code-analysis-template.docx",

--- a/src/test/ut/java/fr/cnes/sonar/report/factory/ReportFactoryTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/factory/ReportFactoryTest.java
@@ -2,6 +2,7 @@ package fr.cnes.sonar.report.factory;
 
 import fr.cnes.sonar.report.CommonTest;
 import fr.cnes.sonar.report.exceptions.BadExportationDataTypeException;
+import fr.cnes.sonar.report.utils.StringManager;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.xmlbeans.XmlException;
 import org.junit.Assert;
@@ -9,6 +10,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class ReportFactoryTest extends CommonTest {
 
@@ -22,6 +25,13 @@ public class ReportFactoryTest extends CommonTest {
     public void formatFilenameWithValidDate() throws ParseException {
         String actual = ReportFactory.formatFilename("report.output", "./target", "2021-03-31", "CNES Report");
         String expected = "./target/2021-03-31-CNES Report-analysis-report.docx";
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void formatFilenameWithEmptyDate() throws ParseException {
+        String actual = ReportFactory.formatFilename("report.output", "./target", "", "CNES Report");
+        String expected = String.format("./target/%s-CNES Report-analysis-report.docx", new SimpleDateFormat(StringManager.DATE_PATTERN).format(new Date()));
         Assert.assertEquals(actual, expected);
     }
 

--- a/src/test/ut/java/fr/cnes/sonar/report/factory/ReportFactoryTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/factory/ReportFactoryTest.java
@@ -18,4 +18,20 @@ public class ReportFactoryTest extends CommonTest {
         Assert.assertTrue(true);
     }
 
+    @Test
+    public void formatFilenameWithValidDate() throws ParseException {
+        String actual = ReportFactory.formatFilename("report.output", "./target", "2021-03-31", "CNES Report");
+        String expected = "./target/2021-03-31-CNES Report-analysis-report.docx";
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void formatFilenameWithBadDateFormat() throws ParseException {
+        String actual = ReportFactory.formatFilename("report.output", "./target", "30-03-2021", "CNES Report");
+    }
+
+    @Test(expected = ParseException.class)
+    public void formatFilenameWithInconsistentDate() throws ParseException {
+        String actual = ReportFactory.formatFilename("report.output", "./target", "2021-12-32", "CNES Report");
+    }
 }

--- a/src/test/ut/java/fr/cnes/sonar/report/factory/ReportFactoryTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/factory/ReportFactoryTest.java
@@ -8,11 +8,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 public class ReportFactoryTest extends CommonTest {
 
     @Test
-    public void createTest() throws XmlException, BadExportationDataTypeException, OpenXML4JException, IOException {
+    public void createTest() throws XmlException, BadExportationDataTypeException, OpenXML4JException, IOException, ParseException {
         ReportFactory.report(conf, report);
         Assert.assertTrue(true);
     }


### PR DESCRIPTION
## Proposed changes

Fix the value of the date in the generated reports filenames when using -d option.

This follows #192: before this change, the date in the filenames was the current date instead of the date passed in argument.

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #192 

## Checklist

> _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
