### PR TITLE
Bugfix version argument not working (#190)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,10 @@
             <id>louisjdmartin</id>
             <name>Louis Martin</name>
         </developer>
+        <developer>
+            <id>ErwanGauduchon</id>
+            <name>Erwan Gauduchon</name>
+        </developer>
     </developers>
 
     <dependencies>
@@ -171,6 +175,15 @@
 
     <build>
         <testSourceDirectory>src/test/ut/java</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources-filtered</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
 
             <plugin>

--- a/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
+++ b/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
@@ -100,16 +100,6 @@ public final class ReportCommandLine {
         // assumes the language is set with language_country
         StringManager.changeLocale(conf.getLanguage());
 
-        // Display version information and exit.
-        if(conf.isVersion()) {
-            final String name = ReportCommandLine.class.getPackage().getImplementationTitle();
-            final String version = ReportCommandLine.class.getPackage().getImplementationVersion();
-            final String vendor = ReportCommandLine.class.getPackage().getImplementationVendor();
-            message = String.format("%s %s by %s", name, version, vendor);
-            LOGGER.info(message);
-            System.exit(0);
-        }
-
         // Print information about SonarQube.
         message = String.format("SonarQube URL: %s", conf.getServer());
         LOGGER.info(message);

--- a/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
@@ -122,7 +122,8 @@ public class CommandLineManager {
                     final Properties properties = new Properties();
                     properties.load(input);
                     String version = properties.getProperty("version");
-                    LOGGER.info(version);
+                    String message = String.format("Current version: %s", version);                    
+                    System.out.println(message);
                     System.exit(0);
                 }
             } catch (IOException e) {

--- a/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
@@ -18,10 +18,13 @@ package fr.cnes.sonar.report.utils;
 
 import org.apache.commons.cli.*;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Properties;
 
 /**
  * Manage the command line by parsing it and providing preprocessed data.
@@ -112,6 +115,19 @@ public class CommandLineManager {
         } else if (commandLine.hasOption("h")) {
             printHelp();
             System.exit(0);
+        } else if (commandLine.hasOption("v")) {
+            // Display version information and exit.
+            try(InputStream input = this.getClass().getClassLoader().getResourceAsStream("version.properties")) {
+                if(input!=null) {
+                    final Properties properties = new Properties();
+                    properties.load(input);
+                    String version = properties.getProperty("version");
+                    LOGGER.info(version);
+                    System.exit(0);
+                }
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
         }
     }
 

--- a/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
@@ -123,7 +123,7 @@ public class CommandLineManager {
                     properties.load(input);
                     String version = properties.getProperty("version");
                     String message = String.format("Current version: %s", version);                    
-                    System.out.println(message);
+                    LOGGER.info(message);
                     System.exit(0);
                 }
             } catch (IOException e) {

--- a/src/main/resources-filtered/version.properties
+++ b/src/main/resources-filtered/version.properties
@@ -1,0 +1,19 @@
+#
+# This file is part of cnesreport.
+#
+# cnesreport is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cnesreport is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cnesreport.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Version of cnesreport
+version=${project.version}

--- a/src/test/ut/java/fr/cnes/sonar/report/utils/CommandLineManagerTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/utils/CommandLineManagerTest.java
@@ -42,4 +42,15 @@ public class CommandLineManagerTest {
 		commandLineManager.parse(new String[] { "-h", "this parameter is ignored" });
 		assertThat(commandLineManager.hasOption("-h"), is(true));
 	}
+
+	/**
+	 * Test command line version argument
+	 */
+	@Test
+	public void parseWithVersionOption() {
+		final CommandLineManager commandLineManager = new CommandLineManager();
+		exit.expectSystemExitWithStatus(0);
+		commandLineManager.parse(new String[] { "-v", "this parameter is ignored" });
+		assertThat(commandLineManager.hasOption("-v"), is(true));
+	}
 }


### PR DESCRIPTION
## Proposed changes

Fix the issue when using -v option.

This follows #190: before this change, the version argument was not recognized as a standalone option and it wasn't possible to retrieve the value of the current version.

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #190 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
