### PR TITLE
Bugfix context not used in SonarQube URL (#202)

### DIFF
--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -80,9 +80,9 @@ public class ExportTask implements RequestHandler {
                     request.getParam(PluginStringManager.getProperty("api.report.args.branch"));
 
             // Build SonarQube local URL
-            String port = config.get("sonar.web.port").orElse("9000");
+            String port = config.get("sonar.web.port").orElse(PluginStringManager.getProperty("plugin.defaultPort"));
             String context = config.get("sonar.web.context").orElse("");
-            String sonarUrl = String.format("http://localhost:%s%s", port, context);
+            String sonarUrl = String.format(PluginStringManager.getProperty("plugin.defaultHost"), port, context);
 
             ReportCommandLine.execute(new String[]{
                     "report",

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -81,7 +81,7 @@ public class ExportTask implements RequestHandler {
 
             // Build SonarQube local URL
             String port = config.get("sonar.web.port").orElse(PluginStringManager.getProperty("plugin.defaultPort"));
-            String context = config.get("sonar.web.context").orElse("");
+            String context = config.get("sonar.web.context").orElse(PluginStringManager.getProperty("plugin.defaultContext"));
             String sonarUrl = String.format(PluginStringManager.getProperty("plugin.defaultHost"), port, context);
 
             ReportCommandLine.execute(new String[]{

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -19,6 +19,8 @@ homepage.url=cnesreport/report
 homepage.name=CNES Report
 
 plugin.since=6.5
+plugin.defaultHost=http://localhost:%s%s
+plugin.defaultPort=9000
 
 api.url=api/cnesreport
 api.description=Export a report in zip file.

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -21,6 +21,7 @@ homepage.name=CNES Report
 plugin.since=6.5
 plugin.defaultHost=http://localhost:%s%s
 plugin.defaultPort=9000
+plugin.defaultContext=
 
 api.url=api/cnesreport
 api.description=Export a report in zip file.


### PR DESCRIPTION
## Proposed changes

Fix the local SonarQube URL used for generating the report when `sonar.web.context` is defined.

This follows #202: before this change, the plugin couldn't use an URL with a path after the root URL.

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #202

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
