### PR TITLE
fix invalid value of parameter 'facets' (#172)

### DIFF
--- a/src/main/resources/requests.properties
+++ b/src/main/resources/requests.properties
@@ -44,7 +44,7 @@ GET_QUALITY_PROFILES_PROJECTS_REQUEST = %s/api/qualityprofiles/projects?key=%s
 # Request to get the list of projects linked to a profile in SQ 5.X
 GET_PROJECT_QUALITY_PROFILES_REQUEST = %s/api/qualityprofiles/search?projectKey=%s
 # Request to get the list of issues linked to a project
-GET_ISSUES_REQUEST = %s/api/issues/search?projects=%s&facets=types,rules,severities,directories,fileUuids,tags&ps=%d&p=%d&additionalFields=rules,comments&resolved=%s&branch=%s
+GET_ISSUES_REQUEST = %s/api/issues/search?projects=%s&facets=types,rules,severities,directories,files,tags&ps=%d&p=%d&additionalFields=rules,comments&resolved=%s&branch=%s
 # Request to get the list of a project's facets
 GET_FACETS_REQUEST = %s/api/issues/search?projects=%s&resolved=false&facets=rules,severities,types&ps=1&p=1&branch=%s
 # Request to get the list of a project's facets


### PR DESCRIPTION
## Proposed changes

Renamed one value of parameter 'facets' ('fileUuids' renamed to 'files') in the API call 'api/issues/search'.

This follows #172: before this change, the plugin was raising an error because of an API change in SonarQube 8.5.

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Fix #172 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
