### PR TITLE
Fix duplicate API call in plugin webpage initialization (#213)

### DIFF
--- a/src/main/js/common/api.js
+++ b/src/main/js/common/api.js
@@ -21,11 +21,15 @@ export function getProjectsList(){
   return getJSON("/api/components/search", {"qualifiers": "TRK", "ps":elementByPage}).then(response => {
     const nbProjects = response.paging.total;
     let nbPages = Math.ceil(nbProjects/elementByPage);
-    //Fill an array of promises
-    for(let i = 1; i <= nbPages; i++){
-      allPromises.push(getJSON("/api/components/search", {"qualifiers": "TRK", "ps":elementByPage, "p":i}).then(response => {
-        return response.components;
-      }));
+    //Store the first page
+    allPromises.push(response.components);
+    //Fill the array of promises with next pages if there are ones
+    if (nbPages >= 2) {
+      for(let i = 2; i <= nbPages; i++){
+        allPromises.push(getJSON("/api/components/search", {"qualifiers": "TRK", "ps":elementByPage, "p":i}).then(response => {
+          return response.components;
+        }));
+      }
     }
     //Wait until all promises are done
     return Promise.all(allPromises);


### PR DESCRIPTION
## Proposed changes

Fix a duplicate API call when loading the plugin webpage.
This follows #213: before this change, two requests giving the same result were executed in a row.

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #213 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
