### PR TITLE
Change deprecated parameters in api calls

### DIFF
--- a/src/main/resources/requests.properties
+++ b/src/main/resources/requests.properties
@@ -32,13 +32,13 @@ GET_QUALITY_GATES_DETAILS_REQUEST = %s/api/qualitygates/show?name=%s
 # Retrieve projects linked to a quality gate in SQ 5.X
 QUALITY_GATE_PROJECTS_REQUEST = %s/api/qualitygates/search?gateId=%s&query=%s
 # Request to get the list of quality profiles
-GET_QUALITY_PROFILES_REQUEST = %s/api/qualityprofiles/search?projectKey=%s&organization=%s
+GET_QUALITY_PROFILES_REQUEST = %s/api/qualityprofiles/search?project=%s&organization=%s
 # Request to get the SonarQube server information
 GET_SONARQUBE_INFO_REQUEST = %s/api/system/status
 # Request to get the configuration file of a quality profile
-GET_QUALITY_PROFILES_CONFIGURATION_REQUEST = %s/api/qualityprofiles/export?language=%s&name=%s
+GET_QUALITY_PROFILES_CONFIGURATION_REQUEST = %s/api/qualityprofiles/export?language=%s&qualityProfile=%s
 # Request to get the list of rules of a profile
-GET_QUALITY_PROFILES_RULES_REQUEST = %s/api/rules/search?qprofile=%s&f=htmlDesc,name,repo,severity,defaultDebtRemFn,actives&ps=%d&p=%d&actives=true
+GET_QUALITY_PROFILES_RULES_REQUEST = %s/api/rules/search?qprofile=%s&f=htmlDesc,name,repo,severity,defaultRemFn,actives&ps=%d&p=%d&activation=true
 # Request to get the list of projects linked to a profile
 GET_QUALITY_PROFILES_PROJECTS_REQUEST = %s/api/qualityprofiles/projects?key=%s
 # Request to get the list of projects linked to a profile in SQ 5.X


### PR DESCRIPTION
## Proposed changes

Replace api calls parameters which have been deprecated since the last LTS version of SonarQube.

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #215 

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [ ] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] SonarCloud and Travis CI tests pass with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
