### PR TITLE
Fix wrong colors in docx report charts

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/DataAdapter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/DataAdapter.java
@@ -247,7 +247,7 @@ public final class DataAdapter {
     /**
      * List of possible issue types
      */
-    private static final String[] ISSUE_TYPES = {"VULNERABILITY", "BUG", "CODE_SMELL"};
+    private static final String[] ISSUE_TYPES = {"BUG", "VULNERABILITY", "CODE_SMELL"};
     /**
      * List of possible issue severities
      */
@@ -369,6 +369,10 @@ public final class DataAdapter {
         return result;
     }
 
+    /**
+     * Getter for SECURITY_HOTSPOT_PRIORITIES
+     * @return SECURITY_HOTSPOT_PRIORITIES
+     */
     public static String[] getSecurityHotspotPriorities() {
         return SECURITY_HOTSPOT_PRIORITIES;
     }
@@ -460,7 +464,26 @@ public final class DataAdapter {
             }
         }
 
+        // sort the result to fit docx template lengends
+        Collections.sort(items, new ValueComparator(facetName));
+        
         return items;
+    }
+
+    /**
+     * Getter for ISSUE_SEVERITIES
+     * @return ISSUE_SEVERITIES
+     */
+    public static String[] getIssueSeverities() {
+        return ISSUE_SEVERITIES;
+    }
+
+    /**
+     * Getter for ISSUE_TYPES
+     * @return ISSUE_TYPES
+     */
+    public static String[] getIssueTypes() {
+        return ISSUE_TYPES;
     }
 
     /**
@@ -810,5 +833,28 @@ class RuleComparator implements Comparator<String>{
         }
 
         return compare;
+    }
+}
+
+/**
+ * ValueComparator is used to compare 2 values to sort them by severity or type
+ */
+class ValueComparator implements Comparator<Value>{
+    String name;
+
+    ValueComparator(String name){
+        this.name = name;
+    }
+
+    public int compare(Value v1, Value v2) {
+       if (this.name.equals("severities")) {
+            List<String> issueSeverities = Arrays.asList(DataAdapter.getIssueSeverities());
+            return issueSeverities.indexOf(v1.getVal()) - issueSeverities.indexOf(v2.getVal());
+       } else if(this.name.equals("types")) {
+            List<String> issueTypes = Arrays.asList(DataAdapter.getIssueTypes());
+            return issueTypes.indexOf(v1.getVal()) - issueTypes.indexOf(v2.getVal());
+       } else {
+           return 0;
+       }
     }
 }

--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/DataAdapter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/DataAdapter.java
@@ -847,14 +847,18 @@ class ValueComparator implements Comparator<Value>{
     }
 
     public int compare(Value v1, Value v2) {
-       if (this.name.equals("severities")) {
+        int compare;
+
+        if (this.name.equals("severities")) {
             List<String> issueSeverities = Arrays.asList(DataAdapter.getIssueSeverities());
-            return issueSeverities.indexOf(v1.getVal()) - issueSeverities.indexOf(v2.getVal());
-       } else if(this.name.equals("types")) {
+            compare = issueSeverities.indexOf(v1.getVal()) - issueSeverities.indexOf(v2.getVal());
+        } else if(this.name.equals("types")) {
             List<String> issueTypes = Arrays.asList(DataAdapter.getIssueTypes());
-            return issueTypes.indexOf(v1.getVal()) - issueTypes.indexOf(v2.getVal());
-       } else {
-           return 0;
-       }
+            compare = issueTypes.indexOf(v1.getVal()) - issueTypes.indexOf(v2.getVal());
+        } else {
+            compare = 0;
+        }
+
+        return compare;
     }
 }

--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/DataAdapter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/DataAdapter.java
@@ -464,7 +464,7 @@ public final class DataAdapter {
             }
         }
 
-        // sort the result to fit docx template lengends
+        // sort the result to fit docx template legends
         Collections.sort(items, new ValueComparator(facetName));
         
         return items;
@@ -837,7 +837,7 @@ class RuleComparator implements Comparator<String>{
 }
 
 /**
- * ValueComparator is used to compare 2 values to sort them by severity or type
+ * ValueComparator is used to compare 2 values of a facet to sort them by severity or type
  */
 class ValueComparator implements Comparator<Value>{
     String name;

--- a/src/test/ut/java/fr/cnes/sonar/report/CommonTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/CommonTest.java
@@ -162,8 +162,10 @@ public abstract class CommonTest {
         rules.setValues(values);
         final List<Value> valuesSeverity = new ArrayList<>();
         valuesSeverity.add(new Value("CRITICAL", 0));
+        valuesSeverity.add(new Value("INFO", 10));
         final List<Value> valuesType = new ArrayList<>();
         valuesType.add(new Value("BUG", 5));
+        valuesType.add(new Value("CODE_SMELL", 15));
         severities.setValues(valuesSeverity);
         types.setValues(valuesType);
         facets.add(rules);


### PR DESCRIPTION
## Proposed changes

Fix color assignment in docx report pie charts.
This follows #166: before this change, the colors specified in the template were not respected.

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #166 

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [ ] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] SonarCloud and Travis CI tests pass with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
