### PR TITLE
Fix parsing exception with technical debt measure

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/DataAdapter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/DataAdapter.java
@@ -17,12 +17,32 @@
 
 package fr.cnes.sonar.report.exporters.docx;
 
-import fr.cnes.sonar.report.model.*;
-import fr.cnes.sonar.report.utils.StringManager;
+import static fr.cnes.sonar.report.utils.MeasureConverter.getIntMeasureFromString;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.logging.Logger;
+
 import org.apache.commons.math3.util.Precision;
 
-import java.util.*;
-import java.util.logging.Logger;
+import fr.cnes.sonar.report.model.Issue;
+import fr.cnes.sonar.report.model.Language;
+import fr.cnes.sonar.report.model.Measure;
+import fr.cnes.sonar.report.model.QualityProfile;
+import fr.cnes.sonar.report.model.Report;
+import fr.cnes.sonar.report.model.Rule;
+import fr.cnes.sonar.report.model.SecurityHotspot;
+import fr.cnes.sonar.report.utils.StringManager;
 
 /**
  * Format resources in different structure to have an easier use
@@ -863,9 +883,9 @@ public final class DataAdapter {
 
         // get metrics values needed
         List<Measure> measures = report.getMeasures();
-        int reliabilityDebt = Integer.parseInt(findMeasure(measures, RELIABILITY_REMEDIATION_EFFORT));
-        int securityDebt = Integer.parseInt(findMeasure(measures, SECURITY_REMEDIATION_EFFORT));
-        int maintainabilityDebt = Integer.parseInt(findMeasure(measures, SQALE_INDEX));
+        int reliabilityDebt = getIntMeasureFromString(findMeasure(measures, RELIABILITY_REMEDIATION_EFFORT));
+        int securityDebt = getIntMeasureFromString(findMeasure(measures, SECURITY_REMEDIATION_EFFORT));
+        int maintainabilityDebt = getIntMeasureFromString(findMeasure(measures, SQALE_INDEX));
         int totalTechnicalDebt = reliabilityDebt + securityDebt + maintainabilityDebt;
 
         String reliabilityDebtFormatted;

--- a/src/main/java/fr/cnes/sonar/report/utils/MeasureConverter.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/MeasureConverter.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of cnesreport.
+ *
+ * cnesreport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cnesreport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cnesreport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.cnes.sonar.report.utils;
+
+public class MeasureConverter {
+
+    private MeasureConverter(){}
+    
+    /**
+     * Parse a string measure into int
+     * @param pMeasure the measure value in string
+     * @return the measure value in int, or 0 if string is not parseable
+     */
+    public static int getIntMeasureFromString(String pMeasure) {
+        int measure;
+
+        try {
+            measure = Integer.parseInt(pMeasure);
+        } catch (NumberFormatException e) {
+            measure = 0;
+        }
+
+        return measure;
+    }
+
+}

--- a/src/test/ut/java/fr/cnes/sonar/report/utils/MeasureConverterTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/utils/MeasureConverterTest.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of cnesreport.
+ *
+ * cnesreport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cnesreport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cnesreport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.cnes.sonar.report.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.Test;
+
+public class MeasureConverterTest {
+
+    @Test
+    public void parseableStringMeasure() {
+        String measure = "35";
+        assertEquals(35, MeasureConverter.getIntMeasureFromString(measure));
+    }
+
+    @Test
+    public void notParseableMeasure() {
+        String measure = "abc";
+        assertEquals(0, MeasureConverter.getIntMeasureFromString(measure));
+        measure = "";
+        assertEquals(0, MeasureConverter.getIntMeasureFromString(measure));
+    }
+    
+}


### PR DESCRIPTION
## Proposed changes

Use a MeasureConverter to parse String measures from SQ API.
If the measure is not parseable, return 0 to continue report generation.

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #280 
- [x] Close #281 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
