### PR TITLE
Get true main branch instead of hardcoded default

### DIFF
--- a/src/main/java/fr/cnes/sonar/plugin/tools/DefaultBranch.java
+++ b/src/main/java/fr/cnes/sonar/plugin/tools/DefaultBranch.java
@@ -1,0 +1,42 @@
+package fr.cnes.sonar.plugin.tools;
+
+import java.util.List;
+
+import org.sonarqube.ws.ProjectBranches.Branch;
+import org.sonarqube.ws.client.WsClient;
+import org.sonarqube.ws.client.projectbranches.ListRequest;
+
+/**
+ * utility class used to determine the MAIN branch of a project 
+ */
+public class DefaultBranch {
+
+    private DefaultBranch(){}
+
+    /**
+     * Method used to retrieve the MAIN branch from a specified project
+     * @param wsClient Class needed to interact with SonarQube classes
+     * @param project Project from which we want the MAIN branch
+     * @return The MAIN branch of the given project
+     */
+    public static String getDefaultBranchFromProject(WsClient wsClient, String project) {
+
+        ListRequest request = new ListRequest().setProject(project);
+        List<Branch> branchesList = wsClient.projectBranches().list(request).getBranchesList();        
+
+        String defaultBranch = "";
+
+        /** In theory, no need to check if the following condition is matched at least once
+         * because SonarQube always defines a MAIN branch inside a project
+         * even if the project is empty
+         */
+        for(Branch branch: branchesList) {
+            if(branch.getIsMain()) {
+                defaultBranch = branch.getName();
+            }
+        }
+
+        return defaultBranch;
+    }
+    
+}

--- a/src/test/ut/java/fr/cnes/sonar/plugin/tools/DefaultBranchTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/plugin/tools/DefaultBranchTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of cnesreport.
+ *
+ * cnesreport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cnesreport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cnesreport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.cnes.sonar.plugin.tools;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sonarqube.ws.ProjectBranches.Branch;
+import org.sonarqube.ws.ProjectBranches.Branch.Builder;
+import org.sonarqube.ws.ProjectBranches.ListWsResponse;
+import org.sonarqube.ws.client.WsClient;
+import org.sonarqube.ws.client.projectbranches.ListRequest;
+import org.sonarqube.ws.client.projectbranches.ProjectBranchesService;
+
+public class DefaultBranchTest {
+
+    @Test
+    public void testGetDefaultBranchFromProject() {
+
+        // Create the request object
+        String project = "whatever";
+
+        // Create the fake list of Branch returned by Sonarqube WS
+        Builder builder = Branch.newBuilder();
+        Branch notMain = builder.setName("notMain").setIsMain(false).build();
+        Branch main = builder.setName("main").setIsMain(true).build();
+        Branch otherNotMain = builder.setName("otherNotMain").setIsMain(false).build();
+
+        // Create the fake WsClient
+        WsClient wsClient = Mockito.mock(WsClient.class);
+        ProjectBranchesService projectBranchesService = Mockito.mock(ProjectBranchesService.class);
+        ListWsResponse listWsResponse = ListWsResponse.newBuilder()
+                .addBranches(0, notMain)
+                .addBranches(1, main)
+                .addBranches(2, otherNotMain)
+                .build();
+        Mockito.when(wsClient.projectBranches()).thenReturn(projectBranchesService);
+        Mockito.when(projectBranchesService.list(Mockito.isA(ListRequest.class))).thenReturn(listWsResponse);
+
+        // Check we get the correct branch
+        assertEquals("main", DefaultBranch.getDefaultBranchFromProject(wsClient, project));
+    }
+
+}


### PR DESCRIPTION
## Proposed changes

In plugin mode, instead of using a hardcoded default value for a project MAIN branch, we may retrieve its true MAIN branch using the dedicated internal SQ class.
This way, we avoid a bug when a user calls the plugin API with a cleaner solution.

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #292 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
