### PR TITLE
Let the tool run even if SonarQube version is not compatible

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
+++ b/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
@@ -137,7 +137,8 @@ public final class ReportCommandLine {
         LOGGER.info(message);
 
         if(!server.isSupported()) {
-            throw new SonarQubeException("SonarQube instance is not supported by cnesreport.");
+            LOGGER.warning("This SonarQube version is not supported by this cnesreport version.");
+            LOGGER.warning("For further information, please refer to the compatibility matrix on the project GitHub page.");
         }
 
         // Generate the model of the report.

--- a/src/main/js/common/api.js
+++ b/src/main/js/common/api.js
@@ -5,9 +5,11 @@
 import { getJSON, postJSON, post } from "sonar-request";
 
 // Function used to get current SonarQube Server version
-function getSonarVersion() {
+export function isCompatible() {
+  const COMPATIBILITY_PATTERN = /8.9(?:\..*)?(?:-.*)?/;
+
   return getJSON("/api/system/status").then(response => {
-    return parseFloat(response.version);
+    return response.version.match(COMPATIBILITY_PATTERN) != null;
   });
 }
 

--- a/src/main/js/components/CnesReportApp.js
+++ b/src/main/js/components/CnesReportApp.js
@@ -64,7 +64,6 @@ export default class CnesReportApp extends React.PureComponent {
         // Initialize compatibility check
         isCompatible().then(isSupported => {
             this.setState({ isSupported });
-            console.log(isSupported);
         });
 
         // Initialize data in form

--- a/src/main/js/components/CnesReportApp.js
+++ b/src/main/js/components/CnesReportApp.js
@@ -125,7 +125,7 @@ export default class CnesReportApp extends React.PureComponent {
                     { !this.state.isSupported &&
                         <div class="compatibility-warning">
                             <p>This SonarQube version is not supported by this cnesreport version.</p>
-                            <p>For further information, please refer to the compatibility matrix on the project GitHub page.</p>
+                            <p>For further information, please refer to the <a href="https://github.com/cnescatlab/sonar-cnes-report#compatibility-matrix">compatibility matrix</a> on the project GitHub page.</p>
                         </div>
                     }
                     <form id="generation-form" action="../../api/cnesreport/report" method="get">

--- a/src/main/js/components/CnesReportApp.js
+++ b/src/main/js/components/CnesReportApp.js
@@ -6,7 +6,7 @@
 import React from "react";
 
 import DeferredSpinner from 'sonar-ui-common/components/ui/DeferredSpinner';
-import { getProjectsList, initiatePluginToken, getBranches } from "../common/api";
+import { getProjectsList, initiatePluginToken, getBranches, isCompatible } from "../common/api";
 
 export default class CnesReportApp extends React.PureComponent {
     state = {
@@ -20,7 +20,8 @@ export default class CnesReportApp extends React.PureComponent {
         enableMd: true,
         enableXlsx: true,
         enableCsv: true,
-        enableConf: true
+        enableConf: true,
+        isSupported: true
     };
 
     onChangeAuthor = (event) => {
@@ -60,6 +61,13 @@ export default class CnesReportApp extends React.PureComponent {
     }
 
     componentDidMount() {
+        // Initialize compatibility check
+        isCompatible().then(isSupported => {
+            this.setState({ isSupported });
+            console.log(isSupported);
+        });
+
+        // Initialize data in form
         initiatePluginToken().then(tokenInfo => {
             getProjectsList().then(projects => {
                 if (projects.length > 0) {
@@ -114,6 +122,12 @@ export default class CnesReportApp extends React.PureComponent {
             <div class="page-wrapper-simple">
                 <div class="page-simple">
                     <h1 class="maintenance-title text-center">Generate a report</h1>
+                    { !this.state.isSupported &&
+                        <div class="compatibility-warning">
+                            <p>This SonarQube version is not supported by this cnesreport version.</p>
+                            <p>For further information, please refer to the compatibility matrix on the project GitHub page.</p>
+                        </div>
+                    }
                     <form id="generation-form" action="../../api/cnesreport/report" method="get">
                         <div class='forminput'>
                             <label for="key" id="keyLabel" class="login-label"><strong>Project</strong></label>

--- a/src/main/js/style.css
+++ b/src/main/js/style.css
@@ -9,3 +9,9 @@
 .info-message{
     color:grey;
 }
+
+.compatibility-warning {
+    padding-bottom: inherit;
+    color: red;
+    font-style: italic;
+}


### PR DESCRIPTION
## Proposed changes

We have a feature that checks the SonarQube version before generating the reports, and throws an exception if the version is not compatible.
Some users would like to try it on non compatible versions because sometimes it "mostly" works.
This feature is preventing them from trying.

Providing a command line flag to bypass this feature would only work for the standalone mode, and nothing clean & easy seems available for the plugin mode.
So, I suggest we change this feature to only show/log a warning to indicate that the version is not compatible, and remind people to have a look at the compatibility matrix. (which is already a regular answer to a lot of issues...)
This way, users can decide to take the risk of getting an exception.

## Types of changes

What types of changes does your code introduce to this software?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #287 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
