### PR TITLE
Fix illegal reflective access operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
             <!-- openxml generation -->
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.17</version>
+            <version>4.1.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/DocXTools.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/DocXTools.java
@@ -27,7 +27,6 @@ import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.poi.xwpf.usermodel.*;
 import org.apache.poi.util.Units;
-import org.apache.xmlbeans.XmlException;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -112,10 +111,9 @@ public final class DocXTools {
      * @param document word document
      * @param facets resources as facets
      * @throws IOException ...
-     * @throws XmlException ...
      */
     public static void fillCharts(XWPFDocument document, Report report)
-            throws IOException, XmlException {
+            throws IOException {
 
         final Facets facets = report.getFacets();
         final TimeFacets timeFacets = report.getTimeFacets();
@@ -127,6 +125,7 @@ public final class DocXTools {
 
         // browse chart list to find placeholders (based on locale) in title
         // and provide them adapted resources
+        
         for (XWPFChartSpace chartSpace : chartSpaces) {
         	
             final String currentChartTitle = chartSpace.getTitle();

--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/XWPFChartSpace.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/XWPFChartSpace.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Lists;
 import fr.cnes.sonar.report.model.Value;
 import fr.cnes.sonar.report.model.TimeValue;
 
-import org.apache.poi.POIXMLDocumentPart;
+import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.xmlbeans.XmlException;

--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/XWPFChartSpace.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/XWPFChartSpace.java
@@ -174,11 +174,11 @@ public class XWPFChartSpace {
             // format date values
             final CTNumData xNumCache = ctPlotArea.getScatterChartList().get(0)
                     .getSerList().get(0).getXVal().getNumRef().getNumCache();
-            xNumCache.setFormatCode("m/d/yyyy\\ h:mm");
+            xNumCache.setFormatCode("dd/mm/yyyy\\ hh:mm");
 
             // format date axis
             final CTNumFmt dateAxisFormat = ctPlotArea.getValAxList().get(1).getNumFmt();
-            dateAxisFormat.setFormatCode("m/d/yyyy\\ h:mm");
+            dateAxisFormat.setFormatCode("dd/mm/yyyy\\ hh:mm");
 
             // write resources in the scatter chart
             for (int i = 0 ; i < values.size() ; i++) {

--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/XWPFChartSpace.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/XWPFChartSpace.java
@@ -177,7 +177,7 @@ public class XWPFChartSpace {
             xNumCache.setFormatCode("dd/mm/yyyy\\ hh:mm");
 
             // format date axis
-            final CTNumFmt dateAxisFormat = ctPlotArea.getValAxList().get(1).getNumFmt();
+            final CTNumFmt dateAxisFormat = ctPlotArea.getValAxList().get(0).getNumFmt();
             dateAxisFormat.setFormatCode("dd/mm/yyyy\\ hh:mm");
 
             // write resources in the scatter chart


### PR DESCRIPTION
## Proposed changes

During report generation, the tool prints this warning : 

> WARNING: An illegal reflective access operation has occurred
> WARNING: Illegal reflective access by org.apache.poi.openxml4j.util.ZipSecureFile$1 (file:/G:/Sonarqube/sonar-cnes-report-4.0.0.jar) to field java.io.FilterInputStream.in
> WARNING: Please consider reporting this to the maintainers of org.apache.poi.openxml4j.util.ZipSecureFile$1
> WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
> WARNING: All illegal access operations will be denied in a future release

These warnings come from the poi-ooxml lib which is used  to generate the reports.
The fix seems to be upgrading this dependency to a newer one (not the latest because of issues with a provided dependency with log4j-api...)

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #307 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
