### PR TITLE
Show information regarding external issues

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/exporters/ConsoleExporter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/ConsoleExporter.java
@@ -52,7 +52,7 @@ public class ConsoleExporter implements IExporter {
         final Report report = (Report) data;
 
         // get issues
-        final List<Issue> issues = report.getIssues();
+        final List<Issue> issues = report.getIssues().getIssuesList();
         String message = "key\tproject\tcomponent\ttype\tseverity\tmessage\tline\tstatus\t";
         LOGGER.info(message);
 

--- a/src/main/java/fr/cnes/sonar/report/exporters/data/IssuesAdapter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/data/IssuesAdapter.java
@@ -103,7 +103,7 @@ public class IssuesAdapter {
         final List<List<String>> formattedIssues = new ArrayList<>(); // result to return
 
         // Get the issues' id
-        final Map<String, Long> items = report.getIssuesFacets();
+        final Map<String, Long> items = report.getIssues().getIssuesFacets();
 
         Map<String, Long> sortedItems = new TreeMap<>(new RuleComparator(report));
         sortedItems.putAll(items);

--- a/src/main/java/fr/cnes/sonar/report/exporters/data/IssuesAdapter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/data/IssuesAdapter.java
@@ -73,7 +73,7 @@ public class IssuesAdapter {
         for (String type : types) {
             // List of items for each line of the table
             final List<String> row = new ArrayList<>();
-            for (Issue issue : report.getIssues()) {
+            for (Issue issue : report.getIssues().getIssuesList()) {
                 if (issue.getType().equals(type)) {
                     // increment the count of the severity
                     countPerSeverity.put(issue.getSeverity(),
@@ -100,7 +100,7 @@ public class IssuesAdapter {
      * @return issues list
      */
     public static List<List<String>> getIssues(Report report) {
-        final List<List<String>> issues = new ArrayList<>(); // result to return
+        final List<List<String>> formattedIssues = new ArrayList<>(); // result to return
 
         // Get the issues' id
         final Map<String, Long> items = report.getIssuesFacets();
@@ -108,38 +108,53 @@ public class IssuesAdapter {
         Map<String, Long> sortedItems = new TreeMap<>(new RuleComparator(report));
         sortedItems.putAll(items);
 
+        List<String> formattedIssue = null;
+        Rule rule = null;
+        Issue issue = null;
+
         for (Map.Entry<String, Long> v : sortedItems.entrySet()) { // construct each issues
-            final List<String> issue = new ArrayList<>();
-            final Rule rule = report.getRule(v.getKey());
+            formattedIssue = new ArrayList<>();
+            rule = report.getRule(v.getKey());
+            issue = report.getIssues().getFirstIssueMatchingRule(v.getKey());
+
             if (rule != null) { // if the rule is found, fill information
                 // add name
-                issue.add(rule.getName());
+                formattedIssue.add(rule.getName());
                 // add description
-                issue.add(rule.getHtmlDesc()
+                formattedIssue.add(rule.getHtmlDesc()
                         .replaceAll(DELETE_HTML_TAGS_REGEX, StringManager.EMPTY));
                 // add type
-                issue.add(rule.getType());
+                formattedIssue.add(rule.getType());
                 // add severity
-                issue.add(rule.getSeverity());
-                // add number
-                issue.add(Long.toString(v.getValue()));
-            } else { // else set just known information
+                formattedIssue.add(rule.getSeverity());
+            } else if (issue != null) { // if if comes from an external analyzer
                 // add name
-                issue.add(v.getKey());
+                formattedIssue.add(issue.getRule());
                 // add description
-                issue.add(QUESTION_MARK);
+                formattedIssue.add(issue.getMessage()
+                        .replaceAll(DELETE_HTML_TAGS_REGEX, StringManager.EMPTY));
                 // add type
-                issue.add(QUESTION_MARK);
+                formattedIssue.add(issue.getType());
                 // add severity
-                issue.add(QUESTION_MARK);
-                // add number
-                issue.add(Long.toString(v.getValue()));
+                formattedIssue.add(issue.getSeverity());
+            }else { // else set just known information
+                // add name
+                formattedIssue.add(v.getKey());
+                // add description
+                formattedIssue.add(QUESTION_MARK);
+                // add type
+                formattedIssue.add(QUESTION_MARK);
+                // add severity
+                formattedIssue.add(QUESTION_MARK);
             }
 
-            issues.add(issue);
+            // add number
+            formattedIssue.add(Long.toString(v.getValue()));
+
+            formattedIssues.add(formattedIssue);
         }
 
-        return issues;
+        return formattedIssues;
     }
 
 }

--- a/src/main/java/fr/cnes/sonar/report/exporters/xlsx/XlsXExporter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/xlsx/XlsXExporter.java
@@ -121,7 +121,7 @@ public class XlsXExporter implements IExporter {
             final XSSFSheet metricsSheet = (XSSFSheet) workbook.getSheet(METRICS_SHEET_NAME);
 
             // write selected resources in the file
-            XlsXTools.addSelectedData(report.getIssues(), selectedSheet, SELECTED_TABLE_NAME);
+            XlsXTools.addSelectedData(report.getIssues().getIssuesList(), selectedSheet, SELECTED_TABLE_NAME);
 
             // write selected resources in the file
             XlsXTools.addSelectedData(report.getUnconfirmed(), unconfirmedSheet, UNCONFIRMED_TABLE_NAME);

--- a/src/main/java/fr/cnes/sonar/report/model/Issues.java
+++ b/src/main/java/fr/cnes/sonar/report/model/Issues.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of cnesreport.
+ *
+ * cnesreport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cnesreport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cnesreport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.cnes.sonar.report.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a list of Issue objects
+ */
+public class Issues {
+
+    /**
+     * List of issues
+     */
+    private List<Issue> issuesList;
+
+    /**
+     * Default constructor
+     */
+    public Issues() {
+        this.issuesList = new ArrayList<>();
+    }
+
+    /**
+     * Setter for issues
+     * @param pIssues List of issues
+     */
+    public void setIssuesList(List<Issue> pIssues) {
+        this.issuesList = new ArrayList<>(pIssues);
+    }
+
+    /**
+     * Get issues List
+     * @return List of issues
+     */
+    public List<Issue> getIssuesList() {
+        return new ArrayList<>(this.issuesList);
+    }
+
+    /**
+     * Get the first Issue matching a given rule
+     * @param pRuleKey
+     * @return The first Issue related to the given rule key
+     */
+    public Issue getFirstIssueMatchingRule(String pRuleKey) {
+        Issue match = null;
+
+        for(Issue issue : this.issuesList) {
+            if (issue.getRule() == pRuleKey) {
+                match = issue;
+                break;
+            }
+        }
+
+        return match;
+    }
+}

--- a/src/main/java/fr/cnes/sonar/report/model/Issues.java
+++ b/src/main/java/fr/cnes/sonar/report/model/Issues.java
@@ -18,7 +18,9 @@
 package fr.cnes.sonar.report.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a list of Issue objects
@@ -39,6 +41,7 @@ public class Issues {
 
     /**
      * Setter for issues
+     * 
      * @param pIssues List of issues
      */
     public void setIssuesList(List<Issue> pIssues) {
@@ -47,6 +50,7 @@ public class Issues {
 
     /**
      * Get issues List
+     * 
      * @return List of issues
      */
     public List<Issue> getIssuesList() {
@@ -54,15 +58,44 @@ public class Issues {
     }
 
     /**
+     * Get number of issues by issue
+     * 
+     * @return issues
+     */
+    public Map<String, Long> getIssuesFacets() {
+        // returned map containing issues key/number of issues
+        final Map<String, Long> lFacets = new HashMap<>();
+        // collect issues' occurrences number
+        long counter;
+        // collect the rule's id for each issue
+        String rule;
+
+        // we browse all the issues and for each issue,
+        // if it is known then we increment its counter
+        // otherwise we add it to the map
+        for (Issue issue : this.issuesList) {
+            rule = issue.getRule();
+            counter = 1;
+            if (lFacets.containsKey(rule)) {
+                counter = lFacets.get(rule) + 1;
+            }
+            lFacets.put(rule, counter);
+        }
+
+        return lFacets;
+    }
+
+    /**
      * Get the first Issue matching a given rule
+     * 
      * @param pRuleKey
      * @return The first Issue related to the given rule key
      */
     public Issue getFirstIssueMatchingRule(String pRuleKey) {
         Issue match = null;
 
-        for(Issue issue : this.issuesList) {
-            if (issue.getRule() == pRuleKey) {
+        for (Issue issue : this.issuesList) {
+            if (pRuleKey.equals(issue.getRule())) {
                 match = issue;
                 break;
             }

--- a/src/main/java/fr/cnes/sonar/report/model/Report.java
+++ b/src/main/java/fr/cnes/sonar/report/model/Report.java
@@ -50,7 +50,7 @@ public class Report {
     /**
      * List of issues detected in the project
      */
-    private List<Issue> issues;
+    private Issues issues;
     /**
      * List of facets of the project
      */
@@ -105,7 +105,7 @@ public class Report {
         this.projectDate = "";
         this.qualityProfiles = new ArrayList<>();
         this.qualityGate = new QualityGate();
-        this.issues = new ArrayList<>();
+        this.issues = new Issues();
         this.unconfirmed = new ArrayList<>();
         this.facets = new Facets();
         this.timeFacets = new TimeFacets();
@@ -136,7 +136,7 @@ public class Report {
         // we browse all the issues and for each issue,
         // if it is known then we increment its counter
         // otherwise we add it to the map
-        for (Issue issue : getIssues()) {
+        for (Issue issue : this.issues.getIssuesList()) {
             rule = issue.getRule();
             counter = 1;
             if (lFacets.containsKey(rule)) {
@@ -165,7 +165,7 @@ public class Report {
 
         if (rulesNumber != 0) {
             Set<String> violatedRules = new HashSet<>();
-            for (Issue issue : this.getIssues()) {
+            for (Issue issue : this.issues.getIssuesList()) {
                 violatedRules.add(issue.getRule());
             }
             for (SecurityHotspot securityHotspot : this.getToReviewSecurityHotspots()) {
@@ -220,8 +220,8 @@ public class Report {
      * 
      * @return issues
      */
-    public List<Issue> getIssues() {
-        return new ArrayList<>(issues);
+    public Issues getIssues() {
+        return issues;
     }
 
     /**
@@ -230,7 +230,7 @@ public class Report {
      * @param pIssues value
      */
     public void setIssues(List<Issue> pIssues) {
-        this.issues = new ArrayList<>(pIssues);
+        this.issues.setIssuesList(pIssues);
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/model/Report.java
+++ b/src/main/java/fr/cnes/sonar/report/model/Report.java
@@ -17,11 +17,17 @@
 
 package fr.cnes.sonar.report.model;
 
-import fr.cnes.sonar.report.utils.StringManager;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.math3.util.Precision;
+
+import fr.cnes.sonar.report.utils.StringManager;
 
 /**
  * Model of a report containing all information
@@ -118,34 +124,6 @@ public class Report {
         this.qualityGateStatus = new HashMap<>();
         this.project = new Project(StringManager.EMPTY, StringManager.EMPTY,
                 StringManager.EMPTY, StringManager.EMPTY, StringManager.EMPTY, StringManager.EMPTY);
-    }
-
-    /**
-     * Get number of issues by issue
-     * 
-     * @return issues
-     */
-    public Map<String, Long> getIssuesFacets() {
-        // returned map containing issues key/number of issues
-        final Map<String, Long> lFacets = new HashMap<>();
-        // collect issues' occurrences number
-        long counter;
-        // collect the rule's id for each issue
-        String rule;
-
-        // we browse all the issues and for each issue,
-        // if it is known then we increment its counter
-        // otherwise we add it to the map
-        for (Issue issue : this.issues.getIssuesList()) {
-            rule = issue.getRule();
-            counter = 1;
-            if (lFacets.containsKey(rule)) {
-                counter = lFacets.get(rule) + 1;
-            }
-            lFacets.put(rule, counter);
-        }
-
-        return lFacets;
     }
 
     /**

--- a/src/test/ut/java/fr/cnes/sonar/report/ReportTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/ReportTest.java
@@ -66,7 +66,7 @@ public class ReportTest {
         assertEquals("", report.getQualityProfilesFilename());
         assert(report.getRawIssues().isEmpty());
         assert(report.getQualityProfiles().isEmpty());
-        assert(report.getIssues().isEmpty());
+        assert(report.getIssues().getIssuesList().isEmpty());
         assert(report.getMeasures().isEmpty());
     }
 

--- a/src/test/ut/java/fr/cnes/sonar/report/exporters/data/IssuesAdapterTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/exporters/data/IssuesAdapterTest.java
@@ -102,14 +102,15 @@ public class IssuesAdapterTest {
 
         // No facets in reports
         List<List<String>> expected = new ArrayList<>();
-        Mockito.when(report.getIssuesFacets()).thenReturn(mockedValue);
+        Mockito.when(report.getIssues()).thenReturn(issues);
+        Mockito.when(issues.getIssuesFacets()).thenReturn(mockedValue);
         Assert.assertEquals(expected, IssuesAdapter.getIssues(report));
 
         // Add some issues facets
         mockedValue.put("test", Long.valueOf(42));
         mockedValue.put("test-external", Long.valueOf(1));
         mockedValue.put("fake", Long.valueOf(234));
-        Mockito.when(report.getIssuesFacets()).thenReturn(mockedValue);
+        Mockito.when(issues.getIssuesFacets()).thenReturn(mockedValue);
 
         // Create test Rule and mock methods
         Rule rule = new Rule();

--- a/src/test/ut/java/fr/cnes/sonar/report/exporters/data/IssuesAdapterTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/exporters/data/IssuesAdapterTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import fr.cnes.sonar.report.model.Issue;
+import fr.cnes.sonar.report.model.Issues;
 import fr.cnes.sonar.report.model.Report;
 import fr.cnes.sonar.report.model.Rule;
 
@@ -47,6 +48,7 @@ public class IssuesAdapterTest {
     @Test
     public void getTypesTest() {
         Report report = Mockito.mock(Report.class);
+        Issues issues = Mockito.mock(Issues.class);
         List<Issue> mockedValue = new ArrayList<>();
 
         // No issues in report
@@ -54,7 +56,8 @@ public class IssuesAdapterTest {
         expected.add(Arrays.asList("BUG", "0", "0", "0", "0", "0"));
         expected.add(Arrays.asList("VULNERABILITY", "0", "0", "0", "0", "0"));
         expected.add(Arrays.asList("CODE_SMELL", "0", "0", "0", "0", "0"));
-        Mockito.when(report.getIssues()).thenReturn(mockedValue);
+        Mockito.when(report.getIssues()).thenReturn(issues);
+        Mockito.when(issues.getIssuesList()).thenReturn(mockedValue);
         Assert.assertEquals(expected, IssuesAdapter.getTypes(report));
 
         // Add some issues
@@ -78,7 +81,7 @@ public class IssuesAdapterTest {
         mockedValue.add(issueSmellCritical);
         mockedValue.add(issueSmellCritical2);
         mockedValue.add(issueVulnInfo);
-        Mockito.when(report.getIssues()).thenReturn(mockedValue);
+        Mockito.when(issues.getIssuesList()).thenReturn(mockedValue);
 
         // Check if result is OK with some issues
         expected = new ArrayList<>();
@@ -94,6 +97,7 @@ public class IssuesAdapterTest {
     @Test
     public void getIssuesTest() {
         Report report = Mockito.mock(Report.class);
+        Issues issues = Mockito.mock(Issues.class);
         Map<String, Long> mockedValue = new HashMap<>();
 
         // No facets in reports
@@ -103,6 +107,7 @@ public class IssuesAdapterTest {
 
         // Add some issues facets
         mockedValue.put("test", Long.valueOf(42));
+        mockedValue.put("test-external", Long.valueOf(1));
         mockedValue.put("fake", Long.valueOf(234));
         Mockito.when(report.getIssuesFacets()).thenReturn(mockedValue);
 
@@ -112,12 +117,21 @@ public class IssuesAdapterTest {
         rule.setHtmlDesc("<p>description</p>");
         rule.setType("CODE_SMELL");
         rule.setSeverity("MINOR");
+        Issue issue = new Issue();
+        issue.setRule("test-external");
+        issue.setMessage("<p>Test description<p>");
+        issue.setType("BUG");
+        issue.setSeverity("MAJOR");
+        Mockito.when(report.getIssues()).thenReturn(issues);
+        Mockito.when(issues.getFirstIssueMatchingRule("test-external")).thenReturn(issue);
         Mockito.when(report.getRule("test")).thenReturn(rule);
+        Mockito.when(report.getRule("test-external")).thenReturn(null);
         Mockito.when(report.getRule("fake")).thenReturn(null);
 
         // Check result
         expected.add(Arrays.asList("test-rule", "description", "CODE_SMELL", "MINOR", "42"));
         expected.add(Arrays.asList("fake", "?", "?", "?", "234"));
+        expected.add(Arrays.asList("test-external", "Test description", "BUG", "MAJOR", "1"));
         Assert.assertEquals(expected, IssuesAdapter.getIssues(report));
     }
 }


### PR DESCRIPTION
## Proposed changes

When a project contains issues from external tools, no data is provided on these issues.
That's because we cross-check data with the Quality Profile, and some external issues are not in Quality Profiles anymore.
For SonarQube issues, data should be taken from the Quality Profile who is the most reliable source regarding severity.
For external issues, we must rely on issues themselves as they are the only source of data...

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #317 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
