### PR TITLE
Improve filename control

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
@@ -25,12 +25,12 @@ import fr.cnes.sonar.report.exporters.xlsx.XlsXExporter;
 import fr.cnes.sonar.report.model.ProfileMetaData;
 import fr.cnes.sonar.report.model.QualityProfile;
 import fr.cnes.sonar.report.model.Report;
+import fr.cnes.sonar.report.utils.FileNameUtils;
 import fr.cnes.sonar.report.utils.ReportConfiguration;
 import fr.cnes.sonar.report.utils.StringManager;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.xmlbeans.XmlException;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -41,9 +41,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
-
-import com.google.common.escape.Escaper;
-import com.google.common.escape.Escapers;
 
 public class ReportFactory {
 
@@ -65,8 +62,6 @@ public class ReportFactory {
     private static final String DATE = "DATE";
     /** Placeholder for the name of the project. */
     private static final String NAME = "NAME";
-    /** Property for fileseparators replace character. */
-    private static final String FILESEPARATORS_REPLACE_CHAR = "report.fileseparators.replace";
     /** Logger of this class. */
     private static final Logger LOGGER = Logger.getLogger(ReportFactory.class.getName());
 
@@ -235,20 +230,7 @@ public class ReportFactory {
         return StringManager.getProperty(propertyName)
                 .replaceFirst(BASEDIR, Matcher.quoteReplacement(baseDir))
                 .replace(DATE, dateStr)
-                .replace(NAME, escapeProjectName(projectName));
-    }
-
-    /**
-     * Escapes the folder seperator from the project name.
-     * @param projectName
-     * @return file seperator (/ or \) escaped project name.
-     */
-    private static CharSequence escapeProjectName(String projectName) {
-        Escaper escaper = Escapers.builder().addEscape(
-            File.separatorChar, 
-            StringManager.getProperty(FILESEPARATORS_REPLACE_CHAR)
-        ).build();
-        return escaper.escape(projectName);
+                .replace(NAME, FileNameUtils.replaceNonValidFileNameCharacter(projectName));
     }
 
 }

--- a/src/main/java/fr/cnes/sonar/report/utils/FileNameUtils.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/FileNameUtils.java
@@ -1,0 +1,27 @@
+package fr.cnes.sonar.report.utils;
+
+/**
+ * Class used to manipulate/encode/validate filenames
+ */
+public class FileNameUtils {
+
+    private FileNameUtils() {}
+
+    /** Property for regex to identify non valid characters in filename. */
+    private static final String FILENAME_INVALID_REGEX = "report.filenames.invalidCharactersRegex";
+    /** Property for replacement character in filename. */
+    private static final String FILENAME_REPLACE_CHAR = "report.filenames.replacementCharacter";
+
+    /**
+     * Replace non valid character for filenames by a generic one
+     * @param projectName
+     * @return the given string with non valid character replaced by a generic one
+     */
+    public static String replaceNonValidFileNameCharacter(String filename) {
+        String replacementChar = StringManager.getProperty(FILENAME_REPLACE_CHAR);
+        String nonValidCharRegex = StringManager.getProperty(FILENAME_INVALID_REGEX);
+
+        return filename.replaceAll(nonValidCharRegex, replacementChar);
+    }
+
+}

--- a/src/main/resources/report.properties
+++ b/src/main/resources/report.properties
@@ -18,8 +18,10 @@
 #Url of SonarQube
 sonar.url=http://localhost:9000
 
-#Replacement character for fileseparators in NAME
-report.fileseparators.replace=-
+#Regex to identify non valid character for filenames
+report.filenames.invalidCharactersRegex=[\\\\/:*?'\"'<>|]
+#Replacement character for non valid characters in filenames
+report.filenames.replacementCharacter=-
 #Report filename's pattern, DATE and NAME are placeholders
 report.output=BASEDIR/DATE-NAME-analysis-report.docx
 #Issues' list filename's pattern DATE and NAME are placeholders

--- a/src/test/ut/java/fr/cnes/sonar/report/utils/FileNameUtilsTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/utils/FileNameUtilsTest.java
@@ -1,0 +1,22 @@
+package fr.cnes.sonar.report.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.Test;
+
+public class FileNameUtilsTest {
+
+    @Test
+    public void validFilename() {
+        final String expected = "Project_test@S0,a)";
+        final String actual = FileNameUtils.replaceNonValidFileNameCharacter("Project_test@S0,a)");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void invalidFilename() {
+        final String expected = "--------";
+        final String actual = FileNameUtils.replaceNonValidFileNameCharacter("/<>?*|:\\");
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
## Proposed changes

The files and folder generated by the plugin have a name that follows a pattern.
This pattern includes the projectKey or projectName of the SonarQube project.
For projectKey, SonarQube prevents characters that are illegal for filename on system path.
For projectName, we only escaped the FileSeparator characters... so... it appears that some characters are valid on Linux but not on Windows.

The goal is to replace all these illegal characters in projectName so that Windows won't yell at us :)

## Types of changes

What types of changes does your code introduce to this software?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #319 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
