### PR TITLE
report shows sum of metrics for some metrics instead of max 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+[D|d]ockerfile
+*.[D|d]ockerfile
+.dockerignore
+*.git
+*.md
+target
+*.log
+*.jar
+*.war
+*.iml
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+ARG DOCKERHUB_REGISTRY=docker.io
+
+FROM $DOCKERHUB_REGISTRY/maven:3.9.11-eclipse-temurin-17 AS build
+
+WORKDIR /app
+
+COPY . .
+
+RUN mvn clean package
+
+FROM $DOCKERHUB_REGISTRY/openjdk:17-jdk-slim
+
+WORKDIR /app
+
+COPY --from=build /app/target/sonar-cnes-report-*.jar ./sonar-cnes-report.jar
+
+ENTRYPOINT ["java", "-jar", "sonar-cnes-report.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.cnes.sonar</groupId>
     <artifactId>cnesreport</artifactId>
-    <version>5.0.2</version>
+    <version>5.0.3</version>
     <packaging>sonar-plugin</packaging>
 
     <name>SonarQube CNES Report</name>

--- a/src/main/resources/requests.properties
+++ b/src/main/resources/requests.properties
@@ -18,7 +18,9 @@
 #Number max of results per page
 MAX_PER_PAGE_SONARQUBE = 500
 # Request to get the list of components and their metrics
-GET_COMPONENTS_REQUEST = %s/api/measures/component_tree?component=%s&metricKeys=%s&p=%s&ps=%s&branch=%s
+# The qualifiers=FIL parameter ensures we only get file-level components,
+# preventing aggregated metrics that would show sum values instead of per-file values
+GET_COMPONENTS_REQUEST = %s/api/measures/component_tree?component=%s&metricKeys=%s&p=%s&ps=%s&branch=%s&qualifiers=FIL
 # Request to get the list of metrics
 GET_MEASURES_REQUEST = %s/api/measures/component?component=%s&metricKeys=%s&branch=%s
 # Request for getting a specific project

--- a/src/test/ut/java/fr/cnes/sonar/report/model/MaxMetricsFixTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/model/MaxMetricsFixTest.java
@@ -1,0 +1,84 @@
+package fr.cnes.sonar.report.model;
+
+import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test to verify that max metrics are calculated correctly and not showing sum values.
+ * 
+ * This test addresses the issue where complexity, cognitive_complexity, and ncloc
+ * metrics were showing the sum of all files instead of the maximum value per file.
+ * The fix ensures the SonarQube API request includes qualifiers=FIL to get
+ * file-level metrics rather than aggregated project-level metrics.
+ */
+public class MaxMetricsFixTest {
+
+    @Test
+    public void testMaxComplexityNotSum() {
+        // Simulate multiple files with different complexity values
+        ArrayList<Map<String,String>> componentsTest = new ArrayList<>();
+        Components components = new Components();
+
+        // File 1:
+        Map<String,String> file1 = new HashMap<>();
+        file1.put("complexity", "10");
+        file1.put("cognitive_complexity", "15");
+        file1.put("ncloc", "100");
+        
+        // File 2: 
+        // complexity 32 (this should be the max)
+        // cognitive_complexity 45 (this should be the max)
+        // ncloc 200 (this should be the max)
+        Map<String,String> file2 = new HashMap<>();
+        file2.put("complexity", "32");  
+        file2.put("cognitive_complexity", "45");
+        file2.put("ncloc", "200");
+        
+        // File 3: 
+        Map<String,String> file3 = new HashMap<>();
+        file3.put("complexity", "8");
+        file3.put("cognitive_complexity", "12");
+        file3.put("ncloc", "50");
+        
+        componentsTest.add(file1);
+        componentsTest.add(file2);
+        componentsTest.add(file3);
+        components.setComponentsList(componentsTest);
+
+        Map<String, Double> metricStats = components.getMetricStats();
+        
+        // Test that max values are NOT equal to sum values
+        double sumComplexity = 10 + 32 + 8; // = 50
+        double sumCognitive = 15 + 45 + 12; // = 72  
+        double sumNcloc = 100 + 200 + 50; // = 350
+        
+        // Verify max values are correct (not sums)
+        assertTrue(metricStats.containsKey("maxcomplexity"), "maxcomplexity should be present");
+        assertTrue(metricStats.containsKey("maxcognitive_complexity"), "maxcognitive_complexity should be present");
+        assertTrue(metricStats.containsKey("maxncloc"), "maxncloc should be present");
+        
+        double maxComplexity = metricStats.get("maxcomplexity");
+        double maxCognitive = metricStats.get("maxcognitive_complexity");
+        double maxNcloc = metricStats.get("maxncloc");
+        
+        // These should be max values, not sums
+        assertNotEquals(sumComplexity, maxComplexity, "maxcomplexity should not equal sum (would indicate bug)");
+        assertNotEquals(sumCognitive, maxCognitive, "maxcognitive_complexity should not equal sum (would indicate bug)");
+        assertNotEquals(sumNcloc, maxNcloc, "maxncloc should not equal sum (would indicate bug)");
+        
+        // Verify they are actually the correct max values
+        assertTrue(maxComplexity == 32.0, "maxcomplexity should be 32 (the highest individual file complexity)");
+        assertTrue(maxCognitive == 45.0, "maxcognitive_complexity should be 45 (the highest individual file cognitive complexity)");
+        assertTrue(maxNcloc == 200.0, "maxncloc should be 200 (the highest individual file ncloc)");
+        
+        System.out.println("✓ Fix verified: Max metrics are calculated correctly");
+        System.out.println("  maxcomplexity: " + maxComplexity + " (expected: 32, sum would be: " + sumComplexity + ")");
+        System.out.println("  maxcognitive_complexity: " + maxCognitive + " (expected: 45, sum would be: " + sumCognitive + ")");
+        System.out.println("  maxncloc: " + maxNcloc + " (expected: 200, sum would be: " + sumNcloc + ")");
+    }
+}


### PR DESCRIPTION

Fix complexity, cognitive_complexity, ncloc metrics from project-level metrics (sum of all files) to file-level metrics (max of all files).

Tested with Sonarqube server version: 10.7.0.96327
Added Dockerfile for convinience.
Updated pom.xml version to 5.0.3

Disclosure: I used Github Copilot to help with the change. Code is reviewed, built and application is manually tested by me to the best of my knowledge, before submitting this PR.

## Proposed changes

The sonarqube api was not called with the qualifiers=FIL parameter, so for some metrics the reports showed the sum of all metrics of all files instead of the max of all files.

Example:
Sonarqube UI shows this for Cyclomatic Complexity:
The sum of all files is 1238 but the max value on file-by-file basis is 108
<img width="985" height="372" alt="image" src="https://github.com/user-attachments/assets/8ab076e8-c465-4e09-8ca4-570a8f12df9c" />

Before the fix we see the 1238 value for max in the report:
<img width="224" height="322" alt="image" src="https://github.com/user-attachments/assets/546dff31-db0f-4cb0-9171-2286bf8d1625" />


After the fix we see 108 in the report that is max on a file-by-file basis:
<img width="232" height="304" alt="image" src="https://github.com/user-attachments/assets/2add5ad9-545f-4d83-b156-eeb750d31433" />


## Types of changes

What types of changes does your code introduce to this software?
> _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

> _List here all issues closed by your changes. Use a list of items like `- [x] Close #0`_

- [x] Close #446 

## Checklist

> _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
