### PR TITLE
Add an option to bypass the 10K Defect Limit during Report Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Generate editable reports for SonarQube projects.
  -e,--disable-spreadsheet          Disable spreadsheet generation.
  -f,--disable-csv                  Disable csv generation.
  -h,--help                         Display this message.
+ -i,--enableIssuesMultiRequests    Workaround SonarQube 10'000 issues limitation, by multiple requests.
  -l,--language <arg>               Language of the report. Values: en_US, fr_FR. Default: en_US.
  -m,--disable-markdown             Disable markdown generation.
  -n,--template-markdown <arg>      Path to the report template in markdown. Default: usage of internal template.
@@ -49,10 +50,10 @@ Generate editable reports for SonarQube projects.
  -r,--template-report <arg>        Path to the report template. Default: usage of internal template.
  -s,--server <arg>                 Complete URL of the targeted SonarQube server.
  -t,--token <arg>                  SonarQube "User token" of the SonarQube user who has permissions on the project.
+ -u,--maxUrlSize  <arg>            SonarQube WebAPI max URL text-size.
  -v,--version                      Display current version.
  -w,--disable-report               Disable report generation.
  -x,--template-spreadsheet <arg>   Path to the spreadsheet template. Default: usage of internal template.
-
 
 Please report issues at https://github.com/cnescatlab/sonar-cnes-report/issues
 ````

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -26,6 +26,7 @@ import fr.cnes.sonar.report.exceptions.BadExportationDataTypeException;
 import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
 import fr.cnes.sonar.report.exceptions.UnknownQualityGateException;
+import fr.cnes.sonar.report.exceptions.UnsupportedSonarqubeResponseException;
 import fr.cnes.sonar.report.factory.ReportFactory;
 import fr.cnes.sonar.report.utils.StringManager;
 import org.apache.commons.io.FileUtils;
@@ -80,7 +81,8 @@ public class ExportTask implements RequestHandler {
      */
     @Override
     public void handle(Request request, Response response) throws BadExportationDataTypeException, IOException,
-            UnknownQualityGateException, OpenXML4JException, XmlException, SonarQubeException, ParseException {
+            UnknownQualityGateException, OpenXML4JException, XmlException, SonarQubeException, ParseException,
+            UnsupportedSonarqubeResponseException, Exception {
 
         // Get project key
         String projectKey = request.getParam(PluginStringManager.getProperty("api.report.args.key")).getValue();
@@ -116,6 +118,12 @@ public class ExportTask implements RequestHandler {
 
             final Request.StringParam pEnableConf =
                     request.getParam(PluginStringManager.getProperty("api.report.args.enableConf"));
+            
+            final Request.StringParam pEnableIssuesMultiRequests =
+                    request.getParam(PluginStringManager.getProperty("api.report.args.enableIssuesMultiRequests"));
+            
+            final Request.StringParam pMaxUrlSize =
+                    request.getParam(PluginStringManager.getProperty("api.report.args.maxUrlSize"));
 
             // Build SonarQube local URL
             String port = config.get("sonar.web.port").orElse(PluginStringManager.getProperty("plugin.defaultPort"));
@@ -177,6 +185,20 @@ public class ExportTask implements RequestHandler {
             }
             if(pEnableConfValue != null && (pEnableConfValue.equals(FALSE) || pEnableConfValue.equals(NO))) {
                 reportParams.add("-c");
+            }
+            
+            // add param for Workaround SonarQube 10'000 issues limitation
+            {
+	            // use multiple requests
+            	final String pEnableIssuesMultiRequestsValue = pEnableIssuesMultiRequests.getValue();
+	            if((null != pEnableIssuesMultiRequestsValue) && (pEnableIssuesMultiRequestsValue.equals(FALSE) || pEnableIssuesMultiRequestsValue.equals(NO))) {
+	            	reportParams.add("-i");
+	            }
+	            
+	            // SonarQube WebAPI max URL text-size
+	            final String pMaxUrlSizeValue = pMaxUrlSize.getValue();
+	            reportParams.add("-u");
+	            reportParams.add(pMaxUrlSizeValue);
             }
 
             // Execute report generation

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -191,7 +191,7 @@ public class ExportTask implements RequestHandler {
             {
 	            // use multiple requests
             	final String pEnableIssuesMultiRequestsValue = pEnableIssuesMultiRequests.getValue();
-	            if((null != pEnableIssuesMultiRequestsValue) && (pEnableIssuesMultiRequestsValue.equals(FALSE) || pEnableIssuesMultiRequestsValue.equals(NO))) {
+	            if((null != pEnableIssuesMultiRequestsValue) && (!pEnableIssuesMultiRequestsValue.equals(FALSE) && !pEnableIssuesMultiRequestsValue.equals(NO))) {
 	            	reportParams.add("-i");
 	            }
 	            
@@ -221,7 +221,7 @@ public class ExportTask implements RequestHandler {
                 JsonWriter jsonWriter = new JsonWriter(writer);
             ) {
                 jsonWriter.beginObject();
-                jsonWriter.name("error").value(PluginStringManager.getProperty("api.tokenerror"));
+                jsonWriter.name("error").value(PluginStringManager.getProperty("api.exportError") +" "+ e.getMessage());
                 jsonWriter.endObject();
                 jsonWriter.flush();
             }

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ReportWs.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ReportWs.java
@@ -126,6 +126,20 @@ public class ReportWs implements WebService {
         enableConfParam.setRequired(false);
         enableConfParam.setBooleanPossibleValues();
         enableConfParam.setDefaultValue(PluginStringManager.getProperty("api.report.args.defaultValue.enableConf"));
+
+        // Adding enableIssuesMultiRequests argument
+        WebService.NewParam enableIssuesMultiRequests = report.createParam(PluginStringManager.getProperty("api.report.args.enableIssuesMultiRequests"));
+        enableIssuesMultiRequests.setDescription(PluginStringManager.getProperty("api.report.args.description.enableIssuesMultiRequests"));
+        enableIssuesMultiRequests.setRequired(false);
+        enableIssuesMultiRequests.setBooleanPossibleValues();
+        enableIssuesMultiRequests.setDefaultValue(PluginStringManager.getProperty("api.report.args.defaultValue.enableIssuesMultiRequests"));
+
+        // Adding maxUrlSize argument
+        WebService.NewParam maxUrlSize = report.createParam(PluginStringManager.getProperty("api.report.args.maxUrlSize"));
+        maxUrlSize.setDescription(PluginStringManager.getProperty("api.report.args.description.maxUrlSize"));
+        maxUrlSize.setRequired(false);
+        maxUrlSize.setDefaultValue(PluginStringManager.getProperty("api.report.args.defaultValue.maxUrlSize"));
+        maxUrlSize.setExampleValue(PluginStringManager.getProperty("api.report.args.exampleValue.maxUrlSize"));
     }
 }
 

--- a/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
+++ b/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
@@ -32,6 +32,7 @@ import fr.cnes.sonar.report.exceptions.BadExportationDataTypeException;
 import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
 import fr.cnes.sonar.report.exceptions.UnknownQualityGateException;
+import fr.cnes.sonar.report.exceptions.UnsupportedSonarqubeResponseException;
 import fr.cnes.sonar.report.factory.ProviderFactory;
 import fr.cnes.sonar.report.factory.ReportFactory;
 import fr.cnes.sonar.report.factory.ReportModelFactory;
@@ -80,9 +81,7 @@ public final class ReportCommandLine {
             // We use different method because it can be called outside main (for example, in from ReportSonarPlugin)
             execute(args);
 
-        } catch (BadExportationDataTypeException | BadSonarQubeRequestException | IOException |
-                UnknownQualityGateException | OpenXML4JException | XmlException | SonarQubeException |
-                IllegalStateException | IllegalArgumentException | ParseException e) {
+        } catch (Exception e) {
             // it logs all the stack trace
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             System.exit(-1);
@@ -90,7 +89,7 @@ public final class ReportCommandLine {
     }
 
     public static void execute(final String[] args) throws BadExportationDataTypeException , BadSonarQubeRequestException , IOException,
-    UnknownQualityGateException, OpenXML4JException, XmlException, SonarQubeException, ParseException {
+    UnknownQualityGateException, OpenXML4JException, XmlException, SonarQubeException, ParseException, UnsupportedSonarqubeResponseException, Exception {
         // Log message.
         String message;
 
@@ -116,8 +115,9 @@ public final class ReportCommandLine {
 
         // Instantiate a ProviderFactory depending on the execution mode of the application
         ProviderFactory providerFactory;
-        providerFactory = new StandaloneProviderFactory(url, conf.getToken(), conf.getProject(), conf.getBranch());
-
+        providerFactory = new StandaloneProviderFactory(url, conf.getToken(), 
+        		conf.getProject(), conf.getBranch(), 
+        		conf.isEnableIssuesMultiRequests(), conf.getMaxUrlSize());
 
         // Initialize connexion with SonarQube and retrieve primitive information
         final SonarQubeServer server = new ServerFactory(url, providerFactory).create();

--- a/src/main/java/fr/cnes/sonar/report/exceptions/UnsupportedSonarqubeResponseException.java
+++ b/src/main/java/fr/cnes/sonar/report/exceptions/UnsupportedSonarqubeResponseException.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of cnesreport.
+ *
+ * cnesreport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cnesreport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cnesreport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.cnes.sonar.report.exceptions;
+
+/**
+ * Thrown when a request is not recognize by SonarQube
+ */
+public class UnsupportedSonarqubeResponseException extends Exception {
+
+    /**
+     * Constructor
+     * @param message the text to print (exception's details)
+     */
+    public UnsupportedSonarqubeResponseException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fr/cnes/sonar/report/factory/ReportModelFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportModelFactory.java
@@ -132,7 +132,7 @@ public class ReportModelFactory {
         	final List<Map<String, String>> listOfMapOfIssues = new ArrayList<Map<String, String>>();
         	
         	issuesProvider.getIssuesStructures("false", listOfConfirmedIssues, null                   , listOfMapOfIssues);
-        	issuesProvider.getIssuesStructures("true ", null                 , listOfUnconfirmedIssues, null);
+        	issuesProvider.getIssuesStructures("true",  null                 , listOfUnconfirmedIssues, null);
         	
         	report.setIssues(listOfConfirmedIssues);
         	report.setUnconfirmed(listOfUnconfirmedIssues);

--- a/src/main/java/fr/cnes/sonar/report/factory/ReportModelFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportModelFactory.java
@@ -17,10 +17,16 @@
 
 package fr.cnes.sonar.report.factory;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
 import fr.cnes.sonar.report.exceptions.UnknownQualityGateException;
+import fr.cnes.sonar.report.exceptions.UnsupportedSonarqubeResponseException;
 import fr.cnes.sonar.report.model.Components;
+import fr.cnes.sonar.report.model.Issue;
 import fr.cnes.sonar.report.model.Report;
 import fr.cnes.sonar.report.providers.component.ComponentProvider;
 import fr.cnes.sonar.report.providers.facets.FacetsProvider;
@@ -79,8 +85,10 @@ public class ReportModelFactory {
      * @throws BadSonarQubeRequestException when a request to the server is not well-formed
      * @throws UnknownQualityGateException a quality gate is not correct
      * @throws SonarQubeException When an error occurred from SonarQube server.
+     * @throws Exception 
+     * @throws UnsupportedSonarqubeResponseException
      */
-    public Report create() throws BadSonarQubeRequestException, UnknownQualityGateException, SonarQubeException {
+    public Report create() throws BadSonarQubeRequestException, UnknownQualityGateException, SonarQubeException, UnsupportedSonarqubeResponseException, Exception {
         // the new report to return
         final Report report = new Report();
 
@@ -118,9 +126,18 @@ public class ReportModelFactory {
         report.setAnalysisDate(report.getProject().getAnalysisDate());
         report.truncateAnalysisDate();
         // formatted issues, unconfirmed issues and raw issues' setting
-        report.setIssues(issuesProvider.getIssues());
-        report.setUnconfirmed(issuesProvider.getUnconfirmedIssues());
-        report.setRawIssues(issuesProvider.getRawIssues());
+        {
+        	final List<Issue> listOfConfirmedIssues = new ArrayList<Issue>();
+        	final List<Issue> listOfUnconfirmedIssues = new ArrayList<Issue>();
+        	final List<Map<String, String>> listOfMapOfIssues = new ArrayList<Map<String, String>>();
+        	
+        	issuesProvider.getIssuesStructures("false", listOfConfirmedIssues, null                   , listOfMapOfIssues);
+        	issuesProvider.getIssuesStructures("true ", null                 , listOfUnconfirmedIssues, null);
+        	
+        	report.setIssues(listOfConfirmedIssues);
+        	report.setUnconfirmed(listOfUnconfirmedIssues);
+        	report.setRawIssues(listOfMapOfIssues);
+        }
         // facets's setting
         report.setFacets(facetsProvider.getFacets());
         report.setTimeFacets(facetsProvider.getTimeFacets());

--- a/src/main/java/fr/cnes/sonar/report/factory/StandaloneProviderFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/StandaloneProviderFactory.java
@@ -58,7 +58,15 @@ public class StandaloneProviderFactory implements ProviderFactory {
     /**
      * Branch of the project
      */
-    private String branch;    
+    private String branch;
+    /**
+     * workaround SonarQube 10'000 issues limitation, by multiple requests
+     */
+    private boolean enableIssuesMultiRequests;
+    /**
+     * SonarQube WebAPI max URL text-size
+     */
+    private int maxUrlSize;
 	
     /**
      * Constructor.
@@ -66,27 +74,33 @@ public class StandaloneProviderFactory implements ProviderFactory {
      * @param token User's token.
      * @param project Project's id.
      * @param branch Project's branch.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
     */
-	public StandaloneProviderFactory(String server, String token, String project, String branch){
+	public StandaloneProviderFactory(String server, String token, 
+			String project, String branch, 
+			boolean enableIssuesMultiRequests, int maxUrlSize){
 		this.server = server;
 		this.token = token;
 		this.project = project;
 		this.branch = branch;
+		this.enableIssuesMultiRequests = enableIssuesMultiRequests;
+		this.maxUrlSize = maxUrlSize;
 	}
 
     @Override
     public ComponentProvider createComponentProvider() {
-        return new ComponentProviderStandalone(this.server, this.token, this.project, this.branch);
+        return new ComponentProviderStandalone(this.server, this.token, this.project, this.branch, this.enableIssuesMultiRequests, this.maxUrlSize);
     }
 
     @Override
     public FacetsProvider createFacetsProvider() {
-        return new FacetsProviderStandalone(this.server, this.token, this.project, this.branch);
+        return new FacetsProviderStandalone(this.server, this.token, this.project, this.branch, this.enableIssuesMultiRequests, this.maxUrlSize);
     }
 
     @Override
     public IssuesProvider createIssuesProvider() {
-        return new IssuesProviderStandalone(this.server, this.token, this.project, this.branch);
+        return new IssuesProviderStandalone(this.server, this.token, this.project, this.branch, this.enableIssuesMultiRequests, this.maxUrlSize);
     }
 
     @Override
@@ -96,17 +110,17 @@ public class StandaloneProviderFactory implements ProviderFactory {
     
     @Override
     public MeasureProvider createMeasureProvider() {
-        return new MeasureProviderStandalone(this.server, this.token, this.project, this.branch);
+        return new MeasureProviderStandalone(this.server, this.token, this.project, this.branch, this.enableIssuesMultiRequests, this.maxUrlSize);
     }
 
     @Override
     public ProjectProvider createProjectProvider() {
-        return new ProjectProviderStandalone(this.server, this.token, this.project, this.branch, createLanguageProvider());
+        return new ProjectProviderStandalone(this.server, this.token, this.project, this.branch, this.enableIssuesMultiRequests, this.maxUrlSize, createLanguageProvider());
     }
 
     @Override
     public QualityGateProvider createQualityGateProvider() {
-        return new QualityGateProviderStandalone(this.server, this.token, this.project, this.branch);
+        return new QualityGateProviderStandalone(this.server, this.token, this.project, this.branch, this.enableIssuesMultiRequests, this.maxUrlSize);
     }
 
     @Override
@@ -116,7 +130,7 @@ public class StandaloneProviderFactory implements ProviderFactory {
 
     @Override
     public SecurityHotspotsProvider createSecurityHotspotsProvider() {
-        return new SecurityHotspotsProviderStandalone(this.server, this.token, this.project, this.branch);
+        return new SecurityHotspotsProviderStandalone(this.server, this.token, this.project, this.branch, this.enableIssuesMultiRequests, this.maxUrlSize);
     }
 
     @Override

--- a/src/main/java/fr/cnes/sonar/report/providers/AbstractDataProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/AbstractDataProvider.java
@@ -55,6 +55,10 @@ public abstract class AbstractDataProvider {
      */
     protected static final String GET_PROJECT_REQUEST = "GET_PROJECT_REQUEST";
     /**
+     * Parameter corresponding to request all Files, when using WEB-API
+     */
+    protected static final String ALLFILES = "";
+    /**
      * Field to search in json to get the paging section
      */
     protected static final String PAGING = "paging";
@@ -116,6 +120,16 @@ public abstract class AbstractDataProvider {
     protected String branch;
 
     /**
+     * workaround SonarQube 10'000 issues limitation, by multiple requests
+     */
+    protected boolean enableIssuesMultiRequests;
+
+    /**
+     * SonarQube WebAPI max URL text-size
+     */
+    protected int maxUrlSize;
+
+    /**
      * Client to talk with sonarqube's services
      */
 	protected WsClient wsClient;
@@ -159,8 +173,12 @@ public abstract class AbstractDataProvider {
      * @param token String representing the user token.
      * @param project The id of the project to report.
      * @param branch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    protected AbstractDataProvider(final String server, final String token, final String project, final String branch) {
+    protected AbstractDataProvider(final String server, final String token, 
+    		                       final String project, final String branch, 
+    		                       final boolean enableIssuesMultiRequests, final int maxUrlSize) {
         // json tool
         this.gson = new Gson();
         // get sonar server
@@ -171,6 +189,9 @@ public abstract class AbstractDataProvider {
         this.projectKey = project;
         // get branch
         this.branch = branch;
+        
+        this.enableIssuesMultiRequests = enableIssuesMultiRequests;
+        this.maxUrlSize = maxUrlSize;
     }
 
     /**
@@ -281,7 +302,8 @@ public abstract class AbstractDataProvider {
      */
     public JsonObject request(final String request)
             throws BadSonarQubeRequestException, SonarQubeException {
-        // do the request to the server and return a string answer
+
+    	// do the request to the server and return a string answer
         final String raw = stringRequest(request);
 
         // prepare json

--- a/src/main/java/fr/cnes/sonar/report/providers/component/AbstractComponentProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/component/AbstractComponentProvider.java
@@ -51,10 +51,13 @@ public abstract class AbstractComponentProvider extends AbstractDataProvider {
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    protected AbstractComponentProvider(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+    protected AbstractComponentProvider(final String pServer, final String pToken, 
+    		final String pProject, final String pBranch, 
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/providers/component/ComponentProviderStandalone.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/component/ComponentProviderStandalone.java
@@ -36,14 +36,17 @@ public class ComponentProviderStandalone extends AbstractComponentProvider imple
     /**
      * Constructor.
      *
-     * @param server  SonarQube server.
-     * @param token   String representing the user token.
-     * @param project The id of the component to report.
-     * @param project The branch of the component to report.
+     * @param pServer  SonarQube server.
+     * @param pToken   String representing the user token.
+     * @param pProject The id of the component to report.
+     * @param pProject The branch of the component to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    public ComponentProviderStandalone(final String server, final String token, final String project,
-            final String branch) {
-        super(server, token, project, branch);
+    public ComponentProviderStandalone(final String pServer, final String pToken, 
+    		final String pProject, final String pBranch, 
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+    	super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     @Override

--- a/src/main/java/fr/cnes/sonar/report/providers/facets/AbstractFacetsProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/facets/AbstractFacetsProvider.java
@@ -90,10 +90,13 @@ public abstract class AbstractFacetsProvider extends AbstractDataProvider {
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
     protected AbstractFacetsProvider(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+            final String pBranch,
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/providers/facets/FacetsProviderStandalone.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/facets/FacetsProviderStandalone.java
@@ -49,10 +49,13 @@ public class FacetsProviderStandalone extends AbstractFacetsProvider implements 
      * @param pToken   String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch  The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    public FacetsProviderStandalone(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+    public FacetsProviderStandalone(final String pServer, final String pToken, 
+    		final String pProject, final String pBranch,
+    		final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     @Override
@@ -70,7 +73,7 @@ public class FacetsProviderStandalone extends AbstractFacetsProvider implements 
         // prepare the request
         final String request = String.format(getRequest(GET_ISSUES_REQUEST), getServer(), getProjectKey(),
                 getMetrics(PROJECT_FACETS), FACETS_MAX_PER_PAGE, page, getMetrics(PROJECT_ADDITIONAL_FIELDS),
-                FACETS_STATUS, getBranch());
+                FACETS_STATUS, getBranch(), ALLFILES);
         // contact the server to request the resources as json
         return request(request);
     }

--- a/src/main/java/fr/cnes/sonar/report/providers/issues/AbstractIssuesProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/issues/AbstractIssuesProvider.java
@@ -29,6 +29,7 @@ import fr.cnes.sonar.report.model.Rule;
 import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -204,14 +205,40 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
 	        			// do nothing
 	        		} else if (subListOfComponentKeys.size() == 1) {
 	        			// get sub-components
-	        			final List<String> subComps = getSubComponents(subListOfComponentKeys.get(0), "children", "FIL,DIR");
+	        			final Map<String, String> subComps = getSubComponents(subListOfComponentKeys.get(0), "children", "FIL,DIR");
 	        			// check 
 	        			if (subComps.isEmpty()) {
 		        			String errMessage = StringManager.string(StringManager.FILES_OVERFLOW_MSG) +" : for ComponentKey=\""+ subListOfComponentKeys.get(0) +"\"";
 		        			throw new UnsupportedSonarqubeResponseException(errMessage);
 		        		}
+	        			// separate Components's keys according to their qualifier
+	        			final List<String> subComps_FIL = new ArrayList<String>();
+	        			final List<String> subComps_DIR = new ArrayList<String>();
+	        			for (final Map.Entry<String, String> currCompEntry : subComps.entrySet()) {
+	        				final String currCompQualifier = currCompEntry.getValue();
+	        				if (currCompQualifier.equals("FIL")) {
+	        					subComps_FIL.add(currCompEntry.getKey());
+	        				} else if (currCompQualifier.equals("DIR")) {
+	        					subComps_DIR.add(currCompEntry.getKey());
+	        				} else {
+	        					LOGGER.warning("Component qualifier \""+ currCompQualifier +"\", not supported.");
+	        				}
+	        			}
 	        			// split list of sub-compskeys in half
-	        			listOfCompsSubsets.addAll(ListUtils.splitListOfStrings(subComps));
+	        			// the goal here is to split but not too much
+	        			if (subComps_FIL.isEmpty() && subComps_DIR.isEmpty()) {
+	        				// do nothing
+	        			} else if (subComps_FIL.isEmpty()) {
+	        				// split the only list we got
+	        				listOfCompsSubsets.addAll(ListUtils.splitListOfStrings(subComps_DIR));
+	        			} else if (subComps_DIR.isEmpty()) {
+	        				// split the only list we got
+	        				listOfCompsSubsets.addAll(ListUtils.splitListOfStrings(subComps_FIL));
+	        			} else {
+	        				// split is the separation of FIL & DIR Components
+	        				listOfCompsSubsets.add(subComps_FIL);
+	        				listOfCompsSubsets.add(subComps_DIR);
+	        			}
 	        		} else {
 	        			// split list of sub-compskeys in half
 	        			listOfCompsSubsets.addAll(ListUtils.splitListOfStrings(subListOfComponentKeys));
@@ -280,30 +307,54 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
             	// transform json to Issue objects
             	final Map<String, String>[] tmp = (getGson().fromJson(jo.get(ISSUES), Map[].class));
             	// add them to the final result
-            	if (null != listOfMapOfIssues) {
+            	if (null != tmp) {
             		listOfMapOfIssues.addAll(Arrays.asList(tmp));
             	}
             }
             
             // check next results' pages
-            int number = (jo.get(TOTAL).getAsInt());
+            int number = jo.get(TOTAL).getAsInt();
 
             // check overflow
             if (number > MAXIMUM_ISSUES_LIMIT) {
+            	// when WebAPI-pages Overflow
                 number = MAXIMUM_ISSUES_LIMIT;
                 overflow.setValue(true);
+                
                 if (!continueOnError) {
-                	// no need to continue getting a partial list of issues from this Component
+                	// no need to continue iterating on other pages for this Component
+                	// ignore issues found in current page
                 	break;
+                } else {
+                	// store issues found in current page
+                	// and continue iterating on other pages for this Component
+                	if (Boolean.parseBoolean(confirmed)) {
+                		if (null != listOfUnconfirmedIssues) {
+                			listOfUnconfirmedIssues.addAll(Arrays.asList(issuesTemp));
+                		} else {
+                			// do nothing
+                		}
+                	} else {
+                		if (null != listOfConfirmedIssues) {
+                			listOfConfirmedIssues.addAll(Arrays.asList(issuesTemp));
+                		} else {
+                			// do nothing
+                		}
+                	}
                 }
             } else {
+            	// when all results fit in the WebAPI-pages
             	if (Boolean.parseBoolean(confirmed)) {
             		if (null != listOfUnconfirmedIssues) {
             			listOfUnconfirmedIssues.addAll(Arrays.asList(issuesTemp));
+            		} else {
+            			// do nothing
             		}
             	} else {
             		if (null != listOfConfirmedIssues) {
             			listOfConfirmedIssues.addAll(Arrays.asList(issuesTemp));
+            		} else {
+            			// do nothing
             		}
             	}
             }
@@ -325,22 +376,22 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
     }
     
     /**
-     * Generic getter for issues depending on their resolved status
+     * Generic getter for sub-Components's key & qualifier
      * 
      * @param componentID  Compliant with SonarQube WebAPI specs
      * @param strategy     Compliant with SonarQube WebAPI specs
      * @param qualifiers   Compliant with SonarQube WebAPI specs
      * 
-     * @return List of found sub-components's keys
+     * @return Map of found sub-components's keys and their Qualifier
      * 
      * @throws BadSonarQubeRequestException A request is not recognized by the
      *                                      server
      * @throws SonarQubeException           When SonarQube server is not callable.
      * @throws UnsupportedSonarqubeResponseException
      */
-    protected List<String> getSubComponents(final String componentID, final String strategy, final String qualifiers)
+    protected Map<String, String> getSubComponents(final String componentID, final String strategy, final String qualifiers)
             throws BadSonarQubeRequestException, SonarQubeException, UnsupportedSonarqubeResponseException {
-    	final List<String> files = new ArrayList<String>();
+    	final Map<String, String> mapOfSubComponents = new HashMap<String, String>();
     	
     	// stop condition
         boolean goOn = true;
@@ -360,8 +411,9 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
         		if (jsonElemFILE instanceof JsonObject) {
         			final Map<String, JsonElement> file = ((JsonObject) jsonElemFILE).asMap();
         			final JsonElement fileKey = file.get("key");
+        			final JsonElement fileQualifier = file.get("qualifier");
         			
-        			files.add(fileKey.getAsString());
+        			mapOfSubComponents.put(fileKey.getAsString(), fileQualifier.getAsString());
         		} else {
         			String message = "SonarQube WebAPI result not supported : \""+ jsonElemFILE.getClass().getName() +"\"";
         			throw new UnsupportedSonarqubeResponseException(message);
@@ -389,7 +441,7 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
         }
 
         // return the Files
-        return files;
+        return mapOfSubComponents;
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/providers/issues/AbstractIssuesProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/issues/AbstractIssuesProvider.java
@@ -18,19 +18,24 @@
 package fr.cnes.sonar.report.providers.issues;
 
 import fr.cnes.sonar.report.providers.AbstractDataProvider;
+import fr.cnes.sonar.report.utils.ListUtils;
 import fr.cnes.sonar.report.utils.StringManager;
 import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
+import fr.cnes.sonar.report.exceptions.UnsupportedSonarqubeResponseException;
 import fr.cnes.sonar.report.model.Issue;
 import fr.cnes.sonar.report.model.Rule;
 
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import org.apache.commons.lang.mutable.MutableBoolean;
 import org.sonarqube.ws.client.WsClient;
 
 /**
@@ -56,6 +61,10 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
      */
     private static final String ISSUES = "issues";
     /**
+     * Parameter corresponding to Files in the JSON response
+     */
+    private static final String COMPONENTS = "components";
+    /**
      * Name of the SonarQube facets to retrieve from issues
      */
     protected static final String ISSUES_FACETS = "ISSUES_FACETS";
@@ -71,10 +80,13 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
      * @param pToken   String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch  The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    protected AbstractIssuesProvider(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+    protected AbstractIssuesProvider(final String pServer, final String pToken,
+    		final String pProject, final String pBranch,
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     /**
@@ -117,7 +129,7 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
         while (goOn) {
             // get maximum number of results per page
             final int maxPerPage = Integer.parseInt(getRequest(MAX_PER_PAGE_SONARQUBE));
-            final JsonObject jo = getIssuesAsJsonObject(page, maxPerPage, confirmed);
+            final JsonObject jo = getIssuesAsJsonObject(page, maxPerPage, confirmed, "");
             // transform json to Issue and Rule objects
             issuesTemp = (getGson().fromJson(jo.get(ISSUES), Issue[].class));
             rulesTemp = (getGson().fromJson(jo.get(RULES), Rule[].class));
@@ -148,9 +160,243 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
     }
 
     /**
+     * Generic getter for issues depending on their resolved status
+     * 
+     * @param confirmed               equals "true" if Unconfirmed and "false" if confirmed
+     * @param listOfConfirmedIssues   List to fill with confirmed Issues
+     * @param listOfUnconfirmedIssues List to fill with unconfirmed Issues
+     * @param listOfMapOfIssues       List to fill with Issues, each Issue is represented as Map containing Issue parameters
+     * @param listOfComponentKeys     List of Components's keys from which to retrieve associated Issues
+     * @param recOnSubComps           Workaround SonarQube 10'000 issues limitation, using multiple requests.
+     * 
+     * @return void
+     * 
+     * @throws BadSonarQubeRequestException A request is not recognized by the
+     *                                      server
+     * @throws SonarQubeException           When SonarQube server is not callable.
+     * @throws UnsupportedSonarqubeResponseException
+     */
+    protected void getIssuesByStatusAbstract_strategy(
+    		final String confirmed, 
+    		final List<Issue> listOfConfirmedIssues, 
+    		final List<Issue> listOfUnconfirmedIssues, 
+    		final List<Map<String, String>> listOfMapOfIssues, 
+    		final List<String> listOfComponentKeys, 
+    		final boolean recOnSubComps
+    		) throws Exception, BadSonarQubeRequestException, SonarQubeException, UnsupportedSonarqubeResponseException {
+		final List<List<String>> subsetsOfListsOfComponentKeys = ListUtils.splitListOfStrings(listOfComponentKeys, maxUrlSize, 1);
+		
+		for (final List<String> subListOfComponentKeys : subsetsOfListsOfComponentKeys) {	
+	    	// flag when there are too many violation (> MAXIMUM_ISSUES_LIMIT)
+	        final MutableBoolean overflow = new MutableBoolean(false);
+	        
+	        getIssuesByStatusAbstract_oneRequest(confirmed, listOfConfirmedIssues, listOfUnconfirmedIssues, listOfMapOfIssues, subListOfComponentKeys, overflow, !recOnSubComps);
+	        
+	        // in case of overflow we log the problem
+	        if (overflow.isTrue()) {
+	        	if (!recOnSubComps) {
+	        		String message = StringManager.string(StringManager.ISSUES_OVERFLOW_MSG);
+	                LOGGER.warning(message);
+	        	} else {
+	        		final List<List<String>> listOfCompsSubsets = new ArrayList<List<String>>();
+	        		
+	        		if (subListOfComponentKeys.size() < 1) {
+	        			// do nothing
+	        		} else if (subListOfComponentKeys.size() == 1) {
+	        			// get sub-components
+	        			final List<String> subComps = getSubComponents(subListOfComponentKeys.get(0), "children", "FIL,DIR");
+	        			// check 
+	        			if (subComps.isEmpty()) {
+		        			String errMessage = StringManager.string(StringManager.FILES_OVERFLOW_MSG) +" : for ComponentKey=\""+ subListOfComponentKeys.get(0) +"\"";
+		        			throw new UnsupportedSonarqubeResponseException(errMessage);
+		        		}
+	        			// split list of sub-compskeys in half
+	        			listOfCompsSubsets.addAll(ListUtils.splitListOfStrings(subComps));
+	        		} else {
+	        			// split list of sub-compskeys in half
+	        			listOfCompsSubsets.addAll(ListUtils.splitListOfStrings(subListOfComponentKeys));
+	        		}
+	        		
+	        		for (final List<String> compsSubset : listOfCompsSubsets) {
+		        			getIssuesByStatusAbstract_strategy(
+		        					confirmed, 
+		        					listOfConfirmedIssues, 
+				        	    	listOfUnconfirmedIssues, 
+				        	    	listOfMapOfIssues, 
+				        	    	compsSubset, 
+				        	    	recOnSubComps);
+	        		}
+	        	}
+	        }
+    	}
+    }
+    
+    /**
+     * Generic getter for issues depending on their resolved status
+     * 
+     * @param confirmed               equals "true" if Unconfirmed and "false" if confirmed
+     * @param listOfConfirmedIssues   List to fill with confirmed Issues
+     * @param listOfUnconfirmedIssues List to fill with unconfirmed Issues
+     * @param listOfMapOfIssues       List to fill with Issues, each Issue is represented as Map containing Issue parameters
+     * @param listOfComponentKeys     List of Components's keys from which to retrieve associated Issues
+     * @param overflow                This flag will be set True when there are too many violation (> MAXIMUM_ISSUES_LIMIT)
+     * @param continueOnError         To continue requesting next pages, even when exceeding MAXIMUM_ISSUES_LIMIT
+     * 
+     * @return List containing all the issues
+     * 
+     * @throws BadSonarQubeRequestException A request is not recognized by the server
+     * @throws SonarQubeException           When SonarQube server is not callable.
+     */
+    protected void getIssuesByStatusAbstract_oneRequest(
+    		final String confirmed, 
+    		final List<Issue> listOfConfirmedIssues, 
+    		final List<Issue> listOfUnconfirmedIssues, 
+    		final List<Map<String, String>> listOfMapOfIssues, 
+    		final List<String> listOfComponentKeys,
+    		final MutableBoolean overflow,
+    		final boolean continueOnError
+    		) throws BadSonarQubeRequestException, SonarQubeException {	
+    	
+    	// get maximum number of results per page
+        final int maxPerPage = Integer.parseInt(getRequest(MAX_PER_PAGE_SONARQUBE));
+        
+        // multi-pages stop condition
+        boolean goOn = true;
+        
+        //
+        final String segmentationParam = componentKeys(listOfComponentKeys);
+        
+        // search all issues of the project
+        for (int page = 1; goOn; page++) {
+        	final JsonObject jo = getIssuesAsJsonObject(page, maxPerPage, confirmed, segmentationParam);
+            
+        	// transform json to Issue and Rule objects
+            final Issue[] issuesTemp = (getGson().fromJson(jo.get(ISSUES), Issue[].class));
+            final Rule[]  rulesTemp  = (getGson().fromJson(jo.get(RULES), Rule[].class));
+            // association of issues and languages
+            setIssuesLanguage(issuesTemp, rulesTemp);
+            
+            if (null != listOfMapOfIssues) {
+            	// transform json to Issue objects
+            	final Map<String, String>[] tmp = (getGson().fromJson(jo.get(ISSUES), Map[].class));
+            	// add them to the final result
+            	if (null != listOfMapOfIssues) {
+            		listOfMapOfIssues.addAll(Arrays.asList(tmp));
+            	}
+            }
+            
+            // check next results' pages
+            int number = (jo.get(TOTAL).getAsInt());
+
+            // check overflow
+            if (number > MAXIMUM_ISSUES_LIMIT) {
+                number = MAXIMUM_ISSUES_LIMIT;
+                overflow.setValue(true);
+                if (!continueOnError) {
+                	// no need to continue getting a partial list of issues from this Component
+                	break;
+                }
+            } else {
+            	if (Boolean.parseBoolean(confirmed)) {
+            		if (null != listOfUnconfirmedIssues) {
+            			listOfUnconfirmedIssues.addAll(Arrays.asList(issuesTemp));
+            		}
+            	} else {
+            		if (null != listOfConfirmedIssues) {
+            			listOfConfirmedIssues.addAll(Arrays.asList(issuesTemp));
+            		}
+            	}
+            }
+            
+            goOn = (page * maxPerPage) < number;
+        }
+    }
+    
+    /**
+     * Converts a List of ComponentKeys
+     * into a String for SonarQube WebAPI ComponentKey's parameter query-section
+     * 
+     * @param listOfComponentKeys
+     * @return String
+     */
+    private String componentKeys(final List<String> listOfComponentKeys) {
+    	final String strComponentKeys = String.join(",", listOfComponentKeys);
+    	return "&componentKeys="+ strComponentKeys;
+    }
+    
+    /**
+     * Generic getter for issues depending on their resolved status
+     * 
+     * @param componentID  Compliant with SonarQube WebAPI specs
+     * @param strategy     Compliant with SonarQube WebAPI specs
+     * @param qualifiers   Compliant with SonarQube WebAPI specs
+     * 
+     * @return List of found sub-components's keys
+     * 
+     * @throws BadSonarQubeRequestException A request is not recognized by the
+     *                                      server
+     * @throws SonarQubeException           When SonarQube server is not callable.
+     * @throws UnsupportedSonarqubeResponseException
+     */
+    protected List<String> getSubComponents(final String componentID, final String strategy, final String qualifiers)
+            throws BadSonarQubeRequestException, SonarQubeException, UnsupportedSonarqubeResponseException {
+    	final List<String> files = new ArrayList<String>();
+    	
+    	// stop condition
+        boolean goOn = true;
+        // flag when there are too many results (> MAXIMUM_ISSUES_LIMIT)
+        boolean overflow = false;
+        
+        // get maximum number of results per page
+        final int maxPerPage = Integer.parseInt(getRequest(MAX_PER_PAGE_SONARQUBE));
+        
+        // search sub-components
+        for (int page = 1; goOn; page++) {
+        	
+        	final JsonObject jo = getComponentsAsJsonObject(componentID, strategy, qualifiers, page, maxPerPage);
+            // transform json to String FileIDs
+        	final JsonElement jsonElemFILES = jo.get(COMPONENTS);
+        	for (final JsonElement jsonElemFILE : jsonElemFILES.getAsJsonArray().asList()) {
+        		if (jsonElemFILE instanceof JsonObject) {
+        			final Map<String, JsonElement> file = ((JsonObject) jsonElemFILE).asMap();
+        			final JsonElement fileKey = file.get("key");
+        			
+        			files.add(fileKey.getAsString());
+        		} else {
+        			String message = "SonarQube WebAPI result not supported : \""+ jsonElemFILE.getClass().getName() +"\"";
+        			throw new UnsupportedSonarqubeResponseException(message);
+        		}
+        	}
+
+            // check next results' pages
+            int number = (jo.get("paging").getAsJsonObject().get(TOTAL).getAsInt());
+
+            // check overflow
+            if (number > MAXIMUM_ISSUES_LIMIT) {
+                number = MAXIMUM_ISSUES_LIMIT;
+                overflow = true;
+                // from now, pages iteration continues, but we won't get all files
+            }
+            
+            goOn = page * maxPerPage < number;
+        }
+
+        // in case of overflow we log the problem
+        if (overflow) {
+            String message = StringManager.string(StringManager.FILES_OVERFLOW_MSG);
+            LOGGER.warning(message);
+            throw new UnsupportedSonarqubeResponseException(message);
+        }
+
+        // return the Files
+        return files;
+    }
+
+    /**
      * Generic getter for all the issues of a project in a raw format (map)
      * 
      * @return Array containing all the issues as maps
+     * 
      * @throws BadSonarQubeRequestException A request is not recognized by the
      *                                      server
      * @throws SonarQubeException           When SonarQube server is not callable.
@@ -170,7 +416,7 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
         while (goon) {
             // get maximum number of results per page
             final int maxPerPage = Integer.parseInt(getRequest(MAX_PER_PAGE_SONARQUBE));
-            final JsonObject jo = getIssuesAsJsonObject(page, maxPerPage, CONFIRMED);
+            final JsonObject jo = getIssuesAsJsonObject(page, maxPerPage, CONFIRMED, ALLFILES);
             // transform json to Issue objects
             final Map<String, String>[] tmp = (getGson().fromJson(jo.get(ISSUES), Map[].class));
             // add them to the final result
@@ -204,6 +450,7 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
      * 
      * @param ruleKey key of the rule to find
      * @param rules   array of the rules to browse
+     * 
      * @return a String containing the display name of the programming language
      */
     private String findLanguageOf(String ruleKey, Rule[] rules) {
@@ -254,11 +501,33 @@ public abstract class AbstractIssuesProvider extends AbstractDataProvider {
      * @param page       The current page.
      * @param maxPerPage The maximum page size.
      * @param confirmed  Equals "true" if Unconfirmed and "false" if confirmed.
+     * @param files      Scope focus on a list of source file. According to SonarWebAPI, Separator is char ','.
+     * 
      * @return The response as a JsonObject.
+     * 
      * @throws BadSonarQubeRequestException A request is not recognized by the
      *                                      server.
      * @throws SonarQubeException           When SonarQube server is not callable.
      */
-    protected abstract JsonObject getIssuesAsJsonObject(final int page, final int maxPerPage, final String confirmed)
+    protected abstract JsonObject getIssuesAsJsonObject(final int page, final int maxPerPage, final String confirmed, final String additionalParams)
             throws BadSonarQubeRequestException, SonarQubeException;
+
+    /**
+     * Get a JsonObject response from the request for Components (FILE, DIR, ...).
+     * 
+     * @param componentID 
+     * @param strategy    Strategy to search for base component descendants. (For details, please report to SonarQube's Web-API documentation)
+     * @param qualifiers  Comma-separated list of the requested qualifiers. (For details, please report to SonarQube's Web-API documentation)
+     * @param page        The current page.
+     * @param maxPerPage  The maximum page size.
+     * 
+     * @return The response as a JsonObject.
+     * 
+     * @throws BadSonarQubeRequestException A request is not recognized by the
+     *                                      server.
+     * @throws SonarQubeException           When SonarQube server is not callable.
+     */
+    protected abstract JsonObject getComponentsAsJsonObject(final String componentID, final String strategy, final String qualifiers, final int page, final int maxPerPage)
+            throws BadSonarQubeRequestException, SonarQubeException;
+    
 }

--- a/src/main/java/fr/cnes/sonar/report/providers/issues/IssuesProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/issues/IssuesProvider.java
@@ -19,6 +19,7 @@ package fr.cnes.sonar.report.providers.issues;
 
 import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
+import fr.cnes.sonar.report.exceptions.UnsupportedSonarqubeResponseException;
 import fr.cnes.sonar.report.model.Issue;
 
 import java.util.List;
@@ -31,17 +32,18 @@ public interface IssuesProvider {
     /**
      * Get all the real issues of a project
      * @return Array containing all the issues
+     * @throws exception
      * @throws BadSonarQubeRequestException A request is not recognized by the server
      * @throws SonarQubeException When SonarQube server is not callable.
      */
-    List<Issue> getIssues() throws BadSonarQubeRequestException, SonarQubeException;
+    List<Issue> getIssues() throws Exception, BadSonarQubeRequestException, SonarQubeException;
     /**
      * Get all the unconfirmed issues of a project
      * @return Array containing all the issues
      * @throws BadSonarQubeRequestException A request is not recognized by the server
      * @throws SonarQubeException When SonarQube server is not callable.
      */
-    List<Issue> getUnconfirmedIssues() throws BadSonarQubeRequestException, SonarQubeException;
+    List<Issue> getUnconfirmedIssues() throws Exception, BadSonarQubeRequestException, SonarQubeException;
     /**
      * Get all the issues of a project in a raw format (map)
      * @return Array containing all the issues as maps
@@ -49,4 +51,24 @@ public interface IssuesProvider {
      * @throws SonarQubeException When SonarQube server is not callable.
      */
     List<Map<String,String>> getRawIssues() throws BadSonarQubeRequestException, SonarQubeException;
+    
+    /**
+     * Get Issues then fill different structures
+     * 
+     * @param confirmed               
+     * @param listOfConfirmedIssues   Input to fill with confirmed Issues
+     * @param listOfUnconfirmedIssues Input to fill with unconfirmed Issues
+     * @param listOfMapOfIssues       Input to fill with Issues, each Issue is represented as Map containing Issue parameters
+     * 
+     * @throws Exception
+     * @throws BadSonarQubeRequestException
+     * @throws SonarQubeException
+     * @throws UnsupportedSonarqubeResponseException 
+     */
+    void getIssuesStructures(
+    		final String confirmed, 
+    		final List<Issue> listOfConfirmedIssues, 
+    		final List<Issue> listOfUnconfirmedIssues, 
+    		final List<Map<String, String>> listOfMapOfIssues)
+    	throws Exception, BadSonarQubeRequestException, SonarQubeException, UnsupportedSonarqubeResponseException;
 }

--- a/src/main/java/fr/cnes/sonar/report/providers/issues/IssuesProviderStandalone.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/issues/IssuesProviderStandalone.java
@@ -19,8 +19,10 @@ package fr.cnes.sonar.report.providers.issues;
 
 import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
+import fr.cnes.sonar.report.exceptions.UnsupportedSonarqubeResponseException;
 import fr.cnes.sonar.report.model.Issue;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -32,9 +34,11 @@ import com.google.gson.JsonObject;
 public class IssuesProviderStandalone extends AbstractIssuesProvider implements IssuesProvider {
 
     /**
-     * Name of the request for getting issues
+     * Name of the request
      */
     private static final String GET_ISSUES_REQUEST = "GET_ISSUES_REQUEST";
+    private static final String GET_COMPONENTS_LIST_REQUEST	= "GET_COMPONENTS_LIST_REQUEST";
+
 
     /**
      * Complete constructor.
@@ -43,21 +47,24 @@ public class IssuesProviderStandalone extends AbstractIssuesProvider implements 
      * @param pToken   String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch  The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
     public IssuesProviderStandalone(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+            final String pBranch,
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     @Override
     public List<Issue> getIssues()
-            throws BadSonarQubeRequestException, SonarQubeException {
+            throws Exception, BadSonarQubeRequestException, SonarQubeException {
         return getIssuesByStatus(CONFIRMED);
     }
 
     @Override
     public List<Issue> getUnconfirmedIssues()
-            throws BadSonarQubeRequestException, SonarQubeException {
+            throws Exception, BadSonarQubeRequestException, SonarQubeException {
         return getIssuesByStatus(UNCONFIRMED);
     }
 
@@ -66,28 +73,79 @@ public class IssuesProviderStandalone extends AbstractIssuesProvider implements 
      * 
      * @param confirmed equals "true" if Unconfirmed and "false" if confirmed
      * @return List containing all the issues
+     * @throws Exception 
      * @throws BadSonarQubeRequestException A request is not recognized by the
      *                                      server
      * @throws SonarQubeException           When SonarQube server is not callable.
+     * @throws UnsupportedSonarqubeResponseException 
      */
     private List<Issue> getIssuesByStatus(String confirmed)
-            throws BadSonarQubeRequestException, SonarQubeException {
-        return getIssuesByStatusAbstract(confirmed);
+            throws Exception, BadSonarQubeRequestException, SonarQubeException, UnsupportedSonarqubeResponseException {
+//        return getIssuesByStatusAbstract(confirmed);
+    	final List<String> listOfComponentKeys = new ArrayList<String>(1);
+    	listOfComponentKeys.add(getProjectKey());
+       
+    	final List<Issue> listOfUnconfirmedIssues = new ArrayList<Issue>();
+    	
+    	getIssuesByStatusAbstract_strategy(
+        		confirmed, 
+        		new ArrayList<Issue>(), 
+        		listOfUnconfirmedIssues, 
+        		new ArrayList<Map<String, String>>(), 
+        		listOfComponentKeys, 
+        		enableIssuesMultiRequests);
+        return listOfUnconfirmedIssues;
     }
 
     @Override
     public List<Map<String, String>> getRawIssues() throws BadSonarQubeRequestException, SonarQubeException {
         return getRawIssuesAbstract();
     }
+    
+    @Override
+	public void getIssuesStructures(
+    		final String confirmed, 
+    		final List<Issue> listOfConfirmedIssues, 
+    		final List<Issue> listOfUnconfirmedIssues, 
+    		final List<Map<String, String>> listOfMapOfIssues) 
+    	throws Exception, BadSonarQubeRequestException, SonarQubeException, UnsupportedSonarqubeResponseException {
+    	
+    	final List<String> listOfComponentKeys = new ArrayList<String>(1);
+    	listOfComponentKeys.add(getProjectKey());
+    	
+    	getIssuesByStatusAbstract_strategy(
+        		confirmed, 
+    			listOfConfirmedIssues, 
+        		listOfUnconfirmedIssues, 
+        		listOfMapOfIssues, 
+        		listOfComponentKeys, 
+        		enableIssuesMultiRequests
+        		);
+    }
 
     @Override
-    protected JsonObject getIssuesAsJsonObject(final int page, final int maxPerPage, final String confirmed)
+    protected JsonObject getIssuesAsJsonObject(final int page, final int maxPerPage, final String confirmed, 
+    		final String additionalParams)
             throws BadSonarQubeRequestException, SonarQubeException {
         // prepare the server to get all the issues
         final String request = String.format(getRequest(GET_ISSUES_REQUEST), getServer(), getProjectKey(),
                 getMetrics(ISSUES_FACETS), maxPerPage, page, getMetrics(ISSUES_ADDITIONAL_FIELDS), confirmed,
-                getBranch());
+                getBranch(), additionalParams) + additionalParams;
         // perform the request to the server
         return request(request);
     }
+
+    @Override
+    protected JsonObject getComponentsAsJsonObject(final String componentID, final String strategy, final String qualifiers,
+    		final int page, final int maxPerPage)
+            throws BadSonarQubeRequestException, SonarQubeException {
+        // prepare the server to get all the issues
+        final String request = String.format(getRequest(GET_COMPONENTS_LIST_REQUEST), getServer(),
+        		componentID, qualifiers, strategy,
+        		maxPerPage, page,
+        		getBranch());
+        // perform the request to the server
+        return request(request);
+    }
+    
 }

--- a/src/main/java/fr/cnes/sonar/report/providers/measure/AbstractMeasureProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/measure/AbstractMeasureProvider.java
@@ -55,10 +55,13 @@ public abstract class AbstractMeasureProvider extends AbstractDataProvider {
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    protected AbstractMeasureProvider(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+    protected AbstractMeasureProvider(final String pServer, final String pToken, 
+    		final String pProject, final String pBranch,
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/providers/measure/MeasureProviderStandalone.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/measure/MeasureProviderStandalone.java
@@ -41,10 +41,13 @@ public class MeasureProviderStandalone extends AbstractMeasureProvider implement
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    public MeasureProviderStandalone(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+    public MeasureProviderStandalone(final String pServer, final String pToken, 
+    		final String pProject, final String pBranch, 
+    		final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+    	super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     @Override

--- a/src/main/java/fr/cnes/sonar/report/providers/project/AbstractProjectProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/project/AbstractProjectProvider.java
@@ -117,6 +117,11 @@ public abstract class AbstractProjectProvider extends AbstractDataProvider {
         if(null == project.getVersion()) {
             project.setVersion(StringManager.EMPTY);
         }
+        
+        // check branch nullity
+        if(null == project.getBranch()) {
+            project.setBranch(branch);
+        }
 
         return project;
     }

--- a/src/main/java/fr/cnes/sonar/report/providers/project/AbstractProjectProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/project/AbstractProjectProvider.java
@@ -49,11 +49,16 @@ public abstract class AbstractProjectProvider extends AbstractDataProvider {
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      * @param pLanguageProvider The language provider.
      */
     protected AbstractProjectProvider(final String pServer, final String pToken, final String pProject,
-            final String pBranch, final LanguageProvider pLanguageProvider) {
-        super(pServer, pToken, pProject, pBranch);
+            final String pBranch, 
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize, 
+            final LanguageProvider pLanguageProvider) {
+        
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
         this.languageProvider = pLanguageProvider;
     }
 

--- a/src/main/java/fr/cnes/sonar/report/providers/project/ProjectProviderStandalone.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/project/ProjectProviderStandalone.java
@@ -35,11 +35,15 @@ public class ProjectProviderStandalone extends AbstractProjectProvider implement
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      * @param pLanguageProvider The language provider.
      */
-    public ProjectProviderStandalone(final String pServer, final String pToken, final String pProject,
-            final String pBranch, final LanguageProvider pLanguageProvider) {
-        super(pServer, pToken, pProject, pBranch, pLanguageProvider);
+    public ProjectProviderStandalone(final String pServer, final String pToken, 
+    		final String pProject, final String pBranch, 
+    		final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize, 
+    		final LanguageProvider pLanguageProvider) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize, pLanguageProvider);
     }
 
     @Override

--- a/src/main/java/fr/cnes/sonar/report/providers/qualitygate/AbstractQualityGateProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/qualitygate/AbstractQualityGateProvider.java
@@ -119,10 +119,13 @@ public abstract class AbstractQualityGateProvider extends AbstractDataProvider {
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    protected AbstractQualityGateProvider(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+    protected AbstractQualityGateProvider(final String pServer, final String pToken, 
+    		final String pProject, final String pBranch, 
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/providers/qualitygate/QualityGateProviderStandalone.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/qualitygate/QualityGateProviderStandalone.java
@@ -56,10 +56,13 @@ public class QualityGateProviderStandalone extends AbstractQualityGateProvider i
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    public QualityGateProviderStandalone(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+    public QualityGateProviderStandalone(final String pServer, final String pToken, 
+            final String pProject, final String pBranch, 
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+    	super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     @Override

--- a/src/main/java/fr/cnes/sonar/report/providers/securityhotspots/AbstractSecurityHotspotsProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/securityhotspots/AbstractSecurityHotspotsProvider.java
@@ -74,10 +74,13 @@ public abstract class AbstractSecurityHotspotsProvider extends AbstractDataProvi
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
      * @param pBranch The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    protected AbstractSecurityHotspotsProvider(final String pServer, final String pToken, final String pProject,
-            final String pBranch) {
-        super(pServer, pToken, pProject, pBranch);
+    protected AbstractSecurityHotspotsProvider(final String pServer, final String pToken, 
+    		final String pProject, final String pBranch, 
+    	    final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/providers/securityhotspots/SecurityHotspotsProviderStandalone.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/securityhotspots/SecurityHotspotsProviderStandalone.java
@@ -45,14 +45,17 @@ public class SecurityHotspotsProviderStandalone extends AbstractSecurityHotspots
 
     /**
      * Complete constructor.
-     * @param server SonarQube server.
-     * @param token String representing the user token.
-     * @param project The id of the project to report.
-     * @param branch The branch of the project to report.
+     * @param pServer  SonarQube server.
+     * @param pToken   String representing the user token.
+     * @param pProject The id of the project to report.
+     * @param pBranch  The branch of the project to report.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
-    public SecurityHotspotsProviderStandalone(final String server, final String token, final String project,
-            final String branch) {
-        super(server, token, project, branch);
+    public SecurityHotspotsProviderStandalone(final String pServer, final String pToken, 
+    		final String pProject, final String pBranch,
+            final boolean pEnableIssuesMultiRequests, final int pMaxUrlSize) {
+        super(pServer, pToken, pProject, pBranch, pEnableIssuesMultiRequests, pMaxUrlSize);
     }
 
     @Override

--- a/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
@@ -62,7 +62,9 @@ public class CommandLineManager {
             {"m", "disable-markdown", Boolean.FALSE.toString(), "Disable Markdown generation"},
             {"n", "template-markdown", Boolean.TRUE.toString(), "Path to the report template in markdown. Default: usage of internal template."},
             {"r", "template-report", Boolean.TRUE.toString(), "Path to the report template. Default: usage of internal template."},
-            {"x", "template-spreadsheet", Boolean.TRUE.toString(), "Path to the spreadsheet template. Default: usage of internal template."}
+            {"x", "template-spreadsheet", Boolean.TRUE.toString(), "Path to the spreadsheet template. Default: usage of internal template."},
+            {"i", "enableIssuesMultiRequests", Boolean.FALSE.toString(), "Workaround SonarQube 10'000 issues limitation, by multiple requests."},
+            {"u", "maxUrlSize ", Boolean.TRUE.toString(), "SonarQube WebAPI max URL text-size."}
     };
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/utils/ListUtils.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/ListUtils.java
@@ -1,0 +1,109 @@
+package fr.cnes.sonar.report.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class used to transform Lists
+ */
+public class ListUtils {
+
+    private ListUtils() {}
+
+
+    /**
+     * Splits input List<String> into two half List<String>
+     * 
+     * @param input
+     * 
+     * @return a List containing two List<String>
+     */
+    public static List<List<String>> splitListOfStrings(final List<String> input) {
+    	if (input.isEmpty()) {
+    		return new ArrayList<List<String>>(0);
+    	} else if (input.size() == 1) {
+    		final List<List<String>> result = new ArrayList<List<String>>(1);
+    		result.add(input);
+    		return result;
+    	} else {
+    		final List<List<String>> result = new ArrayList<List<String>>(2);
+    		
+    		// split list
+    		final int mid = input.size() / 2;
+    		result.add(input.subList(0, mid));
+    		result.add(input.subList(mid, input.size()));
+    		
+    		return result;
+    	}
+    }
+
+    /**
+     * Splits input List<String> into multiple sub-lists, and group them in a list,
+     * Cut-points are selected according to quantity of Char in each resulting sub-list,
+     * in order to not exceed maxSize, and taking into account a potential future separator size
+     * 
+     * @param input
+     * @param maxSize  Number of char, used as cumulative sizes limit, to select when to cut the input into subset lists
+     * @param sepSize  Potential separator size, for future concatenation
+     * 
+     * @return
+     * 
+     * @throws Exception 
+     */
+    public static List<List<String>> splitListOfStrings(final List<String> input, final int maxSize, final int sepSize) throws Exception {
+    	final List<List<String>> result = new ArrayList<List<String>>();
+    	
+    	int size = 0;
+    	List<String> accu = new ArrayList<String>();
+    	for (final String str : input) {
+    		if (str.length() > maxSize) {
+    			String errMsg = "Error : ComponentKey is too long ("+ str.length() +") : \""+ str +"\"";
+    			throw new Exception(errMsg);
+    		} else {
+	    		final int futureSize = size + sepSize + str.length();
+	    		if (futureSize > maxSize) {
+	    			// flush & reset accu
+	    			result.add(accu);
+	    			accu = new ArrayList<String>();
+	    			// insert
+	    			accu.add(str);
+	    			size  = str.length();
+	    		} else {
+	    			// insert
+	    			accu.add(str);
+	    			size = futureSize;
+	    		}
+    		}
+    	}
+    	// flush & reset accu
+		if (!accu.isEmpty())
+			result.add(accu);
+		
+		return result;
+    }
+    
+    /**
+     * Splits each input List<String> into multiple sub-lists, and group them in a common list,
+     * Cut-points are selected according to quantity of Char in each resulting sub-list,
+     * in order to not exceed maxSize, and taking into account a potential future separator size
+     * 
+     * @param input
+     * @param maxSize  Number of char, used as cumulative sizes limit, to select when to cut the input into subset lists
+     * @param sepSize  Potential separator size, for future concatenation
+     * 
+     * @return
+     * 
+     * @throws Exception 
+     */
+    public static List<List<String>> splitListsOfStrings(final List<List<String>> input, final int maxSize, final int sepSize) throws Exception {
+    	final List<List<String>> result = new ArrayList<List<String>>();
+    	
+    	for (final List<String> listOfStrings : input) {
+    		final List<List<String>> listsOfStrings = splitListOfStrings(listOfStrings, maxSize, sepSize);
+    		result.addAll(listsOfStrings);
+    	}
+    	
+    	return result;
+    }
+
+}

--- a/src/main/java/fr/cnes/sonar/report/utils/ReportConfiguration.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/ReportConfiguration.java
@@ -61,6 +61,10 @@ public class ReportConfiguration {
     private String templateSpreadsheet;
     /** Options for n. */
     private String templateMarkdown;
+    /** Options for i. */
+    private boolean enableIssuesMultiRequests;
+    /** Options for u. */
+    private int maxUrlSize;
 
     /**
      * Private constructor, use create method instead.
@@ -76,9 +80,14 @@ public class ReportConfiguration {
      * @param enableConf Value for c option.
      * @param enableReport Value for w option.
      * @param enableSpreadsheet Value for e option.
+     * @param enableCSV
+     * @param enableMarkdown
      * @param templateReport Value for r option.
      * @param templateSpreadsheet Value for x option.
+     * @param templateMarkdown
      * @param branch Value for b option.
+     * @param pEnableIssuesMultiRequests Workaround SonarQube 10'000 issues limitation, by multiple requests.
+     * @param pMaxUrlSize                SonarQube WebAPI max URL text-size.
      */
     private ReportConfiguration(final boolean help, final boolean version, final String server,
                                 final String token, final String project, final String output,
@@ -86,7 +95,8 @@ public class ReportConfiguration {
                                 final boolean enableConf, final boolean enableReport,
                                 final boolean enableSpreadsheet, final boolean enableCSV,
                                 final boolean enableMarkdown, String templateReport,
-                                final String templateSpreadsheet, final String templateMarkdown, final String branch) {
+                                final String templateSpreadsheet, final String templateMarkdown, final String branch,
+                                final boolean enableIssuesMultiRequests, final int maxUrlSize) {
         this.help = help;
         this.version = version;
         this.server = server;
@@ -105,6 +115,8 @@ public class ReportConfiguration {
         this.templateSpreadsheet = templateSpreadsheet;
         this.templateMarkdown = templateMarkdown;
         this.branch = branch;
+        this.enableIssuesMultiRequests = enableIssuesMultiRequests;
+        this.maxUrlSize = maxUrlSize;
     }
 
     /**
@@ -139,7 +151,9 @@ public class ReportConfiguration {
                 commandLineManager.getOptionValue("r", StringManager.EMPTY),
                 commandLineManager.getOptionValue("x", StringManager.EMPTY),
                 commandLineManager.getOptionValue("n", StringManager.EMPTY),
-                branch.isEmpty()?StringManager.NO_BRANCH:branch
+                branch.isEmpty()?StringManager.NO_BRANCH:branch,
+                commandLineManager.hasOption("i"),  // "i" stands for "iterate"
+                Integer.parseInt(commandLineManager.getOptionValue("u", "1800")) // "u" stands for URL
         );
     }
 
@@ -209,5 +223,13 @@ public class ReportConfiguration {
 
     public String getTemplateMarkdown(){
         return templateMarkdown;
+    }
+
+    public boolean isEnableIssuesMultiRequests() {
+        return enableIssuesMultiRequests;
+    }
+
+    public int getMaxUrlSize(){
+        return maxUrlSize;
     }
 }

--- a/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
@@ -52,6 +52,8 @@ public final class StringManager {
     public static final String SONAR_TOKEN = "sonar.token";
     /** Logged message when there are too much issues to export. */
     public static final String ISSUES_OVERFLOW_MSG = "log.overflow.msg";
+    /** Logged message when there are too much files to export. */
+    public static final String FILES_OVERFLOW_MSG = "log.fileoverflow.msg";
     /** Pattern to format the date. */
     public static final String DATE_PATTERN = "yyyy-MM-dd";
     /** Regular expression to match exactly the date format */

--- a/src/main/js/global_page/components/CnesReportApp.js
+++ b/src/main/js/global_page/components/CnesReportApp.js
@@ -20,7 +20,9 @@ export default class CnesReportApp extends React.PureComponent {
         enableXlsx: true,
         enableCsv: true,
         enableConf: true,
-        isSupported: true
+        isSupported: true,
+        enableIssuesMultiRequests: false,
+        maxUrlSize: '1800'
     };
 
     onChangeAuthor = (event) => {
@@ -50,8 +52,15 @@ export default class CnesReportApp extends React.PureComponent {
             case 'enableConf':
                 this.setState({enableConf: !this.state.enableConf});
                 break;
+            case 'enableIssuesMultiRequests':
+                this.setState({enableIssuesMultiRequests: !this.state.enableIssuesMultiRequests});
+                break;
           }
     }
+
+    onChangeMaxUrlSize = (event) => {
+        this.setState({ maxUrlSize: event.target.value })
+    };
 
     // disable generate button if no checkbox is checked to prevent the generation of an empty zip
     shouldDisableGeneration = () => {
@@ -218,6 +227,27 @@ export default class CnesReportApp extends React.PureComponent {
                                 defaultChecked={this.state.enableConf}
                                 onChange={() => this.onChangeCheckbox('enableConf')}/>
                             <label for="enableConf" id="enableConfLabel"><strong>Enable quality configuration generation</strong></label>
+                        </div>
+                        <div>
+                            <input id="enableIssuesMultiRequestsHidden" type="hidden" value="false" name="enableIssuesMultiRequests" disabled={this.state.enableIssuesMultiRequests}/>
+                            <input type="checkbox"
+                                id="enableIssuesMultiRequests"
+                                name="enableIssuesMultiRequests"
+                                value="true"
+                                defaultChecked={this.state.enableIssuesMultiRequests}
+                                onChange={() => this.onChangeCheckbox('enableIssuesMultiRequests')}/>
+                            <label for="enableIssuesMultiRequests" id="enableIssuesMultiRequestsLabel"><strong>Overcome 10k issues limitation (but slower)</strong></label>
+                        </div>
+                        <div class='forminput'>
+                            <label for="maxUrlSize" id="maxUrlSize" class="login-label"><strong>MaxUrlSize</strong></label>
+                            <input type="text"
+                                id="maxUrlSize"
+                                name="maxUrlSize"
+                                class="login-input"
+                                maxlength="7"
+                                required
+                                placeholder="Max Url Size" value={this.state.maxUrlSize}
+                                onChange={this.onChangeMaxUrlSize} />
                         </div>
                         <br />
                         <input id="generation" name="generation" type="submit" value="Generate"

--- a/src/main/js/project_page/view/CnesReportProject.js
+++ b/src/main/js/project_page/view/CnesReportProject.js
@@ -18,7 +18,9 @@ export default class CnesReportProject extends React.PureComponent {
         enableXlsx: true,
         enableCsv: true,
         enableConf: true,
-        isSupported: true
+        isSupported: true,
+        enableIssuesMultiRequests: false,
+        maxUrlSize: "1800"
     };
 
     onChangeAuthor = (event) => {
@@ -42,8 +44,15 @@ export default class CnesReportProject extends React.PureComponent {
             case 'enableConf':
                 this.setState({enableConf: !this.state.enableConf});
                 break;
+            case 'enableIssuesMultiRequests':
+                this.setState({enableIssuesMultiRequests: !this.state.enableIssuesMultiRequests});
+                break;
           }
     }
+
+	onChangeMaxUrlSize = (event) => {
+        this.setState({ maxUrlSize: event.target.value })
+    };
 
     // disable generate button if no checkbox is checked to prevent the generation of an empty zip
     shouldDisableGeneration = () => {
@@ -163,6 +172,27 @@ export default class CnesReportProject extends React.PureComponent {
                                 defaultChecked={this.state.enableConf}
                                 onChange={() => this.onChangeCheckbox('enableConf')}/>
                             <label for="enableConf" id="enableConfLabel"><strong>Enable quality configuration generation</strong></label>
+                        </div>
+                        <div>
+                            <input id="enableIssuesMultiRequestsHidden" type="hidden" value="false" name="enableIssuesMultiRequests" disabled={this.state.enableIssuesMultiRequests}/>
+                            <input type="checkbox"
+                                id="enableIssuesMultiRequests"
+                                name="enableIssuesMultiRequests"
+                                value="true"
+                                defaultChecked={this.state.enableIssuesMultiRequests}
+                                onChange={() => this.onChangeCheckbox('enableIssuesMultiRequests')}/>
+                            <label for="enableIssuesMultiRequests" id="enableIssuesMultiRequestsLabel"><strong>Overcome 10k issues limitation (but slower)</strong></label>
+                        </div>
+                        <div class='forminput'>
+                            <label for="maxUrlSize" id="maxUrlSize" class="login-label"><strong>MaxUrlSize</strong></label>
+                            <input type="text"
+                                id="maxUrlSize"
+                                name="maxUrlSize"
+                                class="login-input"
+                                maxlength="7"
+                                required
+                                placeholder="Max Url Size" value={this.state.maxUrlSize}
+                                onChange={this.onChangeMaxUrlSize} />
                         </div>
                         <br />
                         <input id="generation" name="generation" type="submit" value="Generate"

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -38,3 +38,4 @@ chart.violations.title=Evolution of number of issues
 chart.technicalDebtRatio.title=Evolution of technical debt ratio (%)
 
 log.overflow.msg=There are more than 10000 issues to export, but SonarQube is not able to provide all issues. Only the 10000 first issues are reported. Please, reduce the number of issues before retrying to export.
+log.fileoverflow.msg=Partial reporting. There are more than 10'000 files, SonarQube can provide only the first 10'000 files.

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -38,3 +38,4 @@ chart.violations.title=Évolution du nombre de violations
 chart.technicalDebtRatio.title=Évolution du ratio de dette technique (%)
 
 log.overflow.msg=Il y a plus de 10000 violations à exporter, mais SonarQube n'est pas capable de fournir toutes les violations. Seules les 10000 première violations sont exportées. Veuillez réduire le nombre de violations avant de retenter d'exporter.
+log.fileoverflow.msg=Rapport incomplet. Il y a plus de 10'000 fichiers, SonarQube peut lister seulement les 10000 premièrs fichiers.

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -61,5 +61,12 @@ api.report.args.defaultValue.enableCsv=true
 api.report.args.enableConf=enableConf
 api.report.args.description.enableConf=Enable export of quality configuration used during analysis
 api.report.args.defaultValue.enableConf=true
+api.report.args.enableIssuesMultiRequests=enableIssuesMultiRequests
+api.report.args.description.enableIssuesMultiRequests=Perform multiple requests to overcome 10k issues limitation
+api.report.args.defaultValue.enableIssuesMultiRequests=false
+api.report.args.maxUrlSize=maxUrlSize
+api.report.args.description.maxUrlSize=SonarQube WebAPI max URL text-size
+api.report.args.defaultValue.maxUrlSize=1800
+api.report.args.exampleValue.maxUrlSize=2000
 
 api.tokenerror=This project can't be exported, please check your token.

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -70,3 +70,4 @@ api.report.args.defaultValue.maxUrlSize=1800
 api.report.args.exampleValue.maxUrlSize=2000
 
 api.tokenerror=This project can't be exported, please check your token.
+api.exportError=This project can't be exported.

--- a/src/main/resources/requests.properties
+++ b/src/main/resources/requests.properties
@@ -39,10 +39,14 @@ GET_QUALITY_PROFILES_RULES_REQUEST = %s/api/rules/search?qprofile=%s&f=%s&ps=%d&
 GET_QUALITY_PROFILES_PROJECTS_REQUEST = %s/api/qualityprofiles/projects?key=%s
 # Request to get the list of issues linked to a project
 GET_ISSUES_REQUEST = %s/api/issues/search?projects=%s&facets=%s&ps=%d&p=%d&additionalFields=%s&resolved=%s&branch=%s
+# Request to get a list of Components from a project
+GET_COMPONENTS_LIST_REQUEST = %s/api/components/tree?component=%s&qualifiers=%s&strategy=%s&ps=%d&p=%d&branch=%s
+# Request to get the list of issues linked to one file of a project
+GET_FILEISSUES_REQUEST = %s/api/issues/search?projects=%s&files=%s&ps=%d&p=%d
 # Request to get the list of a project's languages
 GET_LANGUAGES = %s/api/languages/list
 # Request to get the list of security hotspots linked to a project
-GET_SECURITY_HOTSPOTS_REQUEST = %s/api/hotspots/search?branch=%s&p=%d&project=%s&ps=%d&status=%s
+GET_SECURITY_HOTSPOTS_REQUEST = %s/api/hotspots/search?branch=%s&p=%d&projectKey=%s&ps=%d&status=%s
 # Request to get a specific security hotspot
 GET_SECURITY_HOTSPOT_REQUEST = %s/api/hotspots/show?hotspot=%s
 # Request to get a specific rule

--- a/src/test/ut/java/fr/cnes/sonar/plugin/ws/ReportWsTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/plugin/ws/ReportWsTest.java
@@ -220,4 +220,33 @@ public class ReportWsTest {
                 .possibleValues().contains("no"));
     }
 
+    public void testActionEnableIssuesMultiRequests() {
+        // Control the webservice enableIssuesMultiRequests parameter
+        assertEquals(PluginStringManager.getProperty("api.report.args.description.enableIssuesMultiRequests"),
+                this.reportAction.param(PluginStringManager.getProperty("api.report.args.enableIssuesMultiRequests")).description());
+        assertEquals(false,
+                this.reportAction.param(PluginStringManager.getProperty("api.report.args.enableIssuesMultiRequests")).isRequired());
+        assertEquals(4, this.reportAction.param(PluginStringManager.getProperty("api.report.args.enableIssuesMultiRequests"))
+                .possibleValues().size());
+        assertTrue(this.reportAction.param(PluginStringManager.getProperty("api.report.args.enableIssuesMultiRequests"))
+                .possibleValues().contains("true"));
+        assertTrue(this.reportAction.param(PluginStringManager.getProperty("api.report.args.enableIssuesMultiRequests"))
+                .possibleValues().contains("false"));
+        assertTrue(this.reportAction.param(PluginStringManager.getProperty("api.report.args.enableIssuesMultiRequests"))
+                .possibleValues().contains("yes"));
+        assertTrue(this.reportAction.param(PluginStringManager.getProperty("api.report.args.enableIssuesMultiRequests"))
+                .possibleValues().contains("no"));
+    }
+
+    public void testActionMaxUrlSize() {
+        // Control the webservice maxUrlSize parameter
+        assertEquals(PluginStringManager.getProperty("api.report.args.description.maxUrlSize"),
+                this.reportAction.param(PluginStringManager.getProperty("api.report.args.maxUrlSize")).description());
+        assertEquals(true,
+                this.reportAction.param(PluginStringManager.getProperty("api.report.args.maxUrlSize")).isRequired());
+        assertEquals(PluginStringManager.getProperty("api.report.args.exampleValue.maxUrlSize"),
+                this.reportAction.param(PluginStringManager.getProperty("api.report.args.maxUrlSize")).exampleValue());
+    }
+
+
 }

--- a/src/test/ut/java/fr/cnes/sonar/report/CommonTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/CommonTest.java
@@ -76,6 +76,14 @@ public abstract class CommonTest {
      */
     protected static final String QUALITY_GATE_NAME = "CNES";
     /**
+     * Enable multiple requests to get list of Issues, as a Workaround-strategy for SonarQube 10'000 issues limitation.
+     */
+    protected static final boolean ENABLE_ISSUES_MULTI_REQUESTS = false;
+    /**
+     * SonarQube WebAPI max URL text-size.
+     */
+    protected static final int MAX_URL_SIZE = 1800;
+    /**
      * Stubbed report for report.
      */
     protected Report report;
@@ -138,7 +146,9 @@ public abstract class CommonTest {
             .build();
         wsClient = WsClientFactories.getDefault().newClient(httpConnector);
 
-        standaloneProviderFactory = new StandaloneProviderFactory(conf.getServer(), conf.getToken(), conf.getProject(), conf.getBranch());
+        standaloneProviderFactory = new StandaloneProviderFactory(conf.getServer(), conf.getToken(),
+                                                                  conf.getProject(), conf.getBranch(),
+                                                                  conf.isEnableIssuesMultiRequests(), conf.getMaxUrlSize());
 
         final List<Issue> issues = new ArrayList<>();
         final Issue i1 = new Issue();

--- a/src/test/ut/java/fr/cnes/sonar/report/factory/ReportModelFactoryTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/factory/ReportModelFactoryTest.java
@@ -4,13 +4,15 @@ import fr.cnes.sonar.report.CommonTest;
 import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
 import fr.cnes.sonar.report.exceptions.UnknownQualityGateException;
+import fr.cnes.sonar.report.exceptions.UnsupportedSonarqubeResponseException;
+
 import org.junit.Test;
 
 public class ReportModelFactoryTest extends CommonTest {
 
     @Test(expected = SonarQubeException.class)
     public void createStandaloneTest()
-            throws BadSonarQubeRequestException, SonarQubeException, UnknownQualityGateException {
+            throws BadSonarQubeRequestException, SonarQubeException, UnknownQualityGateException, UnsupportedSonarqubeResponseException, Exception {
         ReportModelFactory reportModelFactory = new ReportModelFactory(conf.getProject(), conf.getBranch(), conf.getAuthor(), conf.getDate(), standaloneProviderFactory);
         reportModelFactory.create();
     }

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/AbstractDataProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/AbstractDataProviderTest.java
@@ -13,7 +13,7 @@ public class AbstractDataProviderTest extends CommonTest {
 
     @Test
     public void createAbstractDataProviderStandalone() {
-        ComponentProviderStandalone componentProvider = new ComponentProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        ComponentProviderStandalone componentProvider = new ComponentProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
 
         assertSame(TOKEN, componentProvider.getToken());
         componentProvider.setToken("sqerv1654dr1gsert");

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/component/AbstractComponentProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/component/AbstractComponentProviderTest.java
@@ -75,7 +75,7 @@ public class AbstractComponentProviderTest {
         JsonObject components;
 
         public ComponentProviderWrapper() {
-            super("server", "token", "project", "branch");
+            super("server", "token", "project", "branch", false, 1800);
         }
 
         /**

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/component/ComponentProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/component/ComponentProviderTest.java
@@ -12,7 +12,7 @@ public class ComponentProviderTest extends CommonTest {
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetComponentsStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        ComponentProvider componentProvider = new ComponentProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        ComponentProvider componentProvider = new ComponentProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         componentProvider.getComponents();
     }
 

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/facets/AbstractFacetsProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/facets/AbstractFacetsProviderTest.java
@@ -155,7 +155,7 @@ public class AbstractFacetsProviderTest {
         JsonObject timeFacets;
 
         public FacetsProviderWrapper() {
-            super("server", "token", "project", "branch");
+            super("server", "token", "project", "branch", false, 1800);
         }
 
         /**

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/facets/FacetsProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/facets/FacetsProviderTest.java
@@ -12,7 +12,7 @@ public class FacetsProviderTest extends CommonTest {
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetFacetsStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        FacetsProvider facetsProvider = new FacetsProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        FacetsProvider facetsProvider = new FacetsProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         facetsProvider.getFacets();
     }    
 
@@ -20,7 +20,7 @@ public class FacetsProviderTest extends CommonTest {
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetTimeFacetsStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        FacetsProvider facetsProvider = new FacetsProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        FacetsProvider facetsProvider = new FacetsProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         facetsProvider.getTimeFacets();
     }    
 

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/issues/AbstractIssuesProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/issues/AbstractIssuesProviderTest.java
@@ -212,7 +212,7 @@ class FakeIssuesProvider extends AbstractIssuesProvider {
     private JsonObject fakeObject;
 
     public FakeIssuesProvider() {
-        super("server", "token", "project", "branch");
+        super("server", "token", "project", "branch", false, 1800);
     }
 
     /**
@@ -250,4 +250,18 @@ class FakeIssuesProvider extends AbstractIssuesProvider {
     public String getProperty(String property) {
         return getRequest(property);
     }
+
+	@Override
+	protected JsonObject getIssuesAsJsonObject(int page, int maxPerPage, String confirmed, String additionalParams)
+			throws BadSonarQubeRequestException, SonarQubeException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	protected JsonObject getComponentsAsJsonObject(String componentID, String strategy, String qualifiers, int page,
+			int maxPerPage) throws BadSonarQubeRequestException, SonarQubeException {
+		// Auto-generated method stub
+		return null;
+	}
 }

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/issues/IssuesProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/issues/IssuesProviderTest.java
@@ -11,20 +11,20 @@ public class IssuesProviderTest extends CommonTest {
     private static final String TOKEN = "token";
 
     @Test(expected = SonarQubeException.class)
-    public void executeFaultyGetIssuesStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        IssuesProvider issuesProvider = new IssuesProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+    public void executeFaultyGetIssuesStandalone() throws Exception, SonarQubeException, BadSonarQubeRequestException {
+        IssuesProvider issuesProvider = new IssuesProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         issuesProvider.getIssues();
     }
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetRawIssuesStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        IssuesProvider issuesProvider = new IssuesProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        IssuesProvider issuesProvider = new IssuesProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         issuesProvider.getRawIssues();
     }
 
     @Test(expected = SonarQubeException.class)
-    public void executeFaultyGetUnconfirmedIssuesStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        IssuesProvider issuesProvider = new IssuesProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+    public void executeFaultyGetUnconfirmedIssuesStandalone() throws SonarQubeException, BadSonarQubeRequestException, Exception {
+        IssuesProvider issuesProvider = new IssuesProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         issuesProvider.getUnconfirmedIssues();
     }
 

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/measure/AbstractMeasureProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/measure/AbstractMeasureProviderTest.java
@@ -79,7 +79,7 @@ public class AbstractMeasureProviderTest {
         JsonObject measures;
 
         public MeasureProviderWrapper() {
-            super("server", "token", "project", "branch");
+            super("server", "token", "project", "branch", false, 1800);
         }
 
         /**

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/measure/MeasureProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/measure/MeasureProviderTest.java
@@ -12,7 +12,7 @@ public class MeasureProviderTest extends CommonTest {
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetMeasuresStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        MeasureProvider measureProvider = new MeasureProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        MeasureProvider measureProvider = new MeasureProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         measureProvider.getMeasures();
     }
 

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/project/AbstractProjectProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/project/AbstractProjectProviderTest.java
@@ -139,7 +139,7 @@ public class AbstractProjectProviderTest {
         JsonObject project;
 
         public ProjectProviderWrapper(final LanguageProvider pLanguageProvider) {
-            super("server", "token", "project", "branch", pLanguageProvider);
+            super("server", "token", "project", "branch", false, 1800, pLanguageProvider);
         }
 
         /**

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/project/ProjectProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/project/ProjectProviderTest.java
@@ -14,14 +14,14 @@ public class ProjectProviderTest extends CommonTest {
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetProjectStandalone() throws SonarQubeException, BadSonarQubeRequestException {
         LanguageProvider languageProvider = new LanguageProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY);
-        ProjectProvider projectProvider = new ProjectProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, languageProvider);
+        ProjectProvider projectProvider = new ProjectProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE, languageProvider);
         projectProvider.getProject(PROJECT_KEY, BRANCH);
     }
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyHasProjectStandalone() throws SonarQubeException, BadSonarQubeRequestException {
         LanguageProvider languageProvider = new LanguageProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY);
-        ProjectProvider projectProvider = new ProjectProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, languageProvider);
+        ProjectProvider projectProvider = new ProjectProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE, languageProvider);
         projectProvider.hasProject(PROJECT_KEY, BRANCH);
     }
 

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/qualitygate/AbstractQualityGateProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/qualitygate/AbstractQualityGateProviderTest.java
@@ -318,7 +318,7 @@ public class AbstractQualityGateProviderTest {
         private JsonObject fakeQualityGateStatus;
 
         public QualityGateProviderWrapper() {
-            super("server", "token", "project", "branch");
+            super("server", "token", "project", "branch", false, 1800);
         }
 
         /**

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/qualitygate/QualityGateProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/qualitygate/QualityGateProviderTest.java
@@ -12,13 +12,13 @@ public class QualityGateProviderTest extends CommonTest {
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetQualityGatesStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        QualityGateProvider qualityGateProvider = new QualityGateProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        QualityGateProvider qualityGateProvider = new QualityGateProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         qualityGateProvider.getQualityGates();
     }
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetQualityGateStatusStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        QualityGateProvider qualityGateProvider = new QualityGateProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        QualityGateProvider qualityGateProvider = new QualityGateProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         qualityGateProvider.getQualityGateStatus();
     }
 

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/securityhotspots/AbstractSecurityHotspotsProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/securityhotspots/AbstractSecurityHotspotsProviderTest.java
@@ -117,7 +117,7 @@ public class AbstractSecurityHotspotsProviderTest {
         JsonObject rule;
 
         public SecurityHotspotsProviderWrapper() {
-            super("server", "token", "project", "branch");
+            super("server", "token", "project", "branch", false, 1800);
         }
 
         /**

--- a/src/test/ut/java/fr/cnes/sonar/report/providers/securityhotspots/SecurityHotspotsProviderTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/providers/securityhotspots/SecurityHotspotsProviderTest.java
@@ -12,13 +12,13 @@ public class SecurityHotspotsProviderTest extends CommonTest {
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetToReviewSecurityHotspotsStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        SecurityHotspotsProvider securityHotspotsProvider = new SecurityHotspotsProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        SecurityHotspotsProvider securityHotspotsProvider = new SecurityHotspotsProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         securityHotspotsProvider.getToReviewSecurityHotspots();
     }
 
     @Test(expected = SonarQubeException.class)
     public void executeFaultyGetReviewedSecurityHotspotsStandalone() throws SonarQubeException, BadSonarQubeRequestException {
-        SecurityHotspotsProvider securityHotspotsProvider = new SecurityHotspotsProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH);
+        SecurityHotspotsProvider securityHotspotsProvider = new SecurityHotspotsProviderStandalone(sonarQubeServer, TOKEN, PROJECT_KEY, BRANCH, ENABLE_ISSUES_MULTI_REQUESTS, MAX_URL_SIZE);
         securityHotspotsProvider.getReviewedSecurityHotspots();
     }
 


### PR DESCRIPTION
## Proposed changes

The following update provides some new options for the user, so that he may create a report with more than 10.000 issues. With this option activated, the whole repository is parsed and the requests for defects are made and grouped to always stay under 10K. The result(s) are then aggregated as one final report. The usage of this option is contained within the README.md file of the repository.

## Types of changes

What types of changes does your code introduce to this software?

- [x] New feature (non-breaking change which adds functionality)

## Issues closed by changes

- [x] Close #371
- [x] Close #354
- [x] Close #188
- [x] Close #5

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules