### PR TITLE
feat: auto-detect project main branch when none is specified

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
+++ b/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
@@ -148,8 +148,21 @@ public final class ReportCommandLine {
                     "For further information, please refer to the compatibility matrix on the project GitHub page.");
         }
 
+        // Resolve the branch: when none is provided, auto-detect the project's main branch.
+        String branch = conf.getBranch();
+        if (branch.isEmpty()) {
+            branch = providerFactory.createSonarQubeInfoProvider().getProjectMainBranch(conf.getProject());
+            if (branch.isEmpty()) {
+                branch = StringManager.NO_BRANCH;
+            }
+            message = String.format("No branch specified, using project main branch: %s", branch);
+            LOGGER.info(message);
+            // Rebuild the provider factory so all providers target the resolved branch.
+            providerFactory = new StandaloneProviderFactory(url, conf.getToken(), conf.getProject(), branch);
+        }
+
         // Generate the model of the report.
-        final Report model = new ReportModelFactory(conf.getProject(), conf.getBranch(), conf.getAuthor(),
+        final Report model = new ReportModelFactory(conf.getProject(), branch, conf.getAuthor(),
                 conf.getDate(), providerFactory).create();
         // Generate results files.
         ReportFactory.report(conf, model);

--- a/src/main/java/fr/cnes/sonar/report/factory/ServerFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ServerFactory.java
@@ -32,7 +32,8 @@ public class ServerFactory {
 
     /** List of SonarQube versions which are supported by cnesreport. */
     private static final List<String> SUPPORTED_VERSIONS = Arrays.asList(
-            "10.*", "10.*.*","25.*", "25.*.*","26.*", "26.*.*");
+            "10.*", "10.*.*","25.*", "25.*.*","26.*", "26.*.*",
+            "2025.*", "2026.*");
 
     /** Url of the SonarQube server. */
     private String url;

--- a/src/main/java/fr/cnes/sonar/report/providers/sonarqubeinfo/SonarQubeInfoProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/sonarqubeinfo/SonarQubeInfoProvider.java
@@ -36,4 +36,12 @@ public interface SonarQubeInfoProvider {
      * @return String containing the SonarQube status.
      */
     String getSonarQubeStatus();
+    /**
+     * Get the name of the main branch of a project.
+     * @param project The key of the project.
+     * @return String containing the name of the main branch, empty if none found.
+     * @throws BadSonarQubeRequestException when the server does not understand the request.
+     * @throws SonarQubeException When SonarQube server is not callable.
+     */
+    String getProjectMainBranch(final String project) throws BadSonarQubeRequestException, SonarQubeException;
 }

--- a/src/main/java/fr/cnes/sonar/report/providers/sonarqubeinfo/SonarQubeInfoProviderStandalone.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/sonarqubeinfo/SonarQubeInfoProviderStandalone.java
@@ -17,6 +17,8 @@
 
 package fr.cnes.sonar.report.providers.sonarqubeinfo;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
@@ -34,6 +36,12 @@ public class SonarQubeInfoProviderStandalone extends AbstractDataProvider implem
      */
     private static final String GET_SONARQUBE_INFO_REQUEST =
             "GET_SONARQUBE_INFO_REQUEST";
+
+    /**
+     *  Name of the request for getting the list of branches of a project
+     */
+    private static final String GET_PROJECT_BRANCHES_REQUEST =
+            "GET_PROJECT_BRANCHES_REQUEST";
 
     /**
      * Complete constructor.
@@ -80,5 +88,33 @@ public class SonarQubeInfoProviderStandalone extends AbstractDataProvider implem
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
         return status;
+    }
+
+    /**
+     * Get the name of the main branch of a project.
+     * @param project The key of the project.
+     * @return String containing the name of the main branch, empty if none found.
+     * @throws BadSonarQubeRequestException when the server does not understand the request.
+     * @throws SonarQubeException When SonarQube server is not callable.
+     */
+    @Override
+    public String getProjectMainBranch(final String project) throws BadSonarQubeRequestException, SonarQubeException {
+        // send a request to sonarqube server and return the response as a json object
+        // if there is an error on server side this method throws an exception
+        final JsonObject jsonObject = request(
+                String.format(getRequest(GET_PROJECT_BRANCHES_REQUEST), getServer(), project));
+
+        // look for the branch flagged as main and return its name
+        String mainBranch = "";
+        final JsonArray branches = jsonObject.getAsJsonArray("branches");
+        if (branches != null) {
+            for (final JsonElement element : branches) {
+                final JsonObject branch = element.getAsJsonObject();
+                if (branch.has("isMain") && branch.get("isMain").getAsBoolean()) {
+                    mainBranch = branch.get("name").getAsString();
+                }
+            }
+        }
+        return mainBranch;
     }
 }

--- a/src/main/java/fr/cnes/sonar/report/utils/ReportConfiguration.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/ReportConfiguration.java
@@ -121,7 +121,8 @@ public class ReportConfiguration {
         commandLineManager.parse(pArgs);
 
         // Final result to return.
-        final String branch = commandLineManager.getOptionValue("b", StringManager.NO_BRANCH);
+        // When no branch is provided, keep it empty so the main branch can be auto-detected later.
+        final String branch = commandLineManager.getOptionValue("b", StringManager.EMPTY);
         return new ReportConfiguration(
                 commandLineManager.hasOption("h"),
                 commandLineManager.hasOption("v"),
@@ -140,8 +141,8 @@ public class ReportConfiguration {
                 commandLineManager.getOptionValue("r", StringManager.EMPTY),
                 commandLineManager.getOptionValue("x", StringManager.EMPTY),
                 commandLineManager.getOptionValue("n", StringManager.EMPTY),
-                branch.isEmpty()?StringManager.NO_BRANCH:branch
-                
+                branch
+
         );
     }
 

--- a/src/main/resources/requests.properties
+++ b/src/main/resources/requests.properties
@@ -31,6 +31,8 @@ GET_QUALITY_GATES_DETAILS_REQUEST = %s/api/qualitygates/show?name=%s
 GET_QUALITY_PROFILES_REQUEST = %s/api/qualityprofiles/search?project=%s
 # Request to get the SonarQube server information
 GET_SONARQUBE_INFO_REQUEST = %s/api/system/status
+# Request to get the list of branches of a project
+GET_PROJECT_BRANCHES_REQUEST = %s/api/project_branches/list?project=%s
 # Request to get the configuration file of a quality profile
 GET_QUALITY_PROFILES_CONFIGURATION_REQUEST = %s/api/qualityprofiles/export?language=%s&qualityProfile=%s
 # Request to get the list of rules of a profile


### PR DESCRIPTION
## Summary

When no `-b/--branch` option is provided on the command line, cnesreport currently falls back to no-branch behavior. This PR makes it query the `api/project_branches/list` endpoint to resolve the project's main branch and target it instead.

## Changes

- Add `getProjectMainBranch(project)` to `SonarQubeInfoProvider` and its standalone implementation, reading the `branches` array and returning the entry flagged `isMain`.
- Add the `GET_PROJECT_BRANCHES_REQUEST` entry in `requests.properties`.
- In `ReportCommandLine`, when the branch is empty, resolve the main branch and rebuild the provider factory so all providers target it (falling back to no-branch when none is found).
- Keep the branch empty in `ReportConfiguration` when no `-b` is passed, so it can be auto-detected later.
- Accept calendar-style version strings (`2025.*`, `2026.*`) as supported in `ServerFactory`.

## Behavior

- `-b` provided → unchanged, uses the given branch.
- `-b` omitted → main branch auto-detected; logs the resolved branch; falls back to no-branch when detection returns nothing.