### PR TITLE
fix: compute token expiration in UTC and surface token errors

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/factory/ServerFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ServerFactory.java
@@ -32,7 +32,8 @@ public class ServerFactory {
 
     /** List of SonarQube versions which are supported by cnesreport. */
     private static final List<String> SUPPORTED_VERSIONS = Arrays.asList(
-            "10.*", "10.*.*","25.*", "25.*.*","26.*", "26.*.*");
+            "10.*", "10.*.*", "25.*", "25.*.*", "26.*", "26.*.*",
+            "2025.*", "2025.*.*", "2026.*", "2026.*.*");
 
     /** Url of the SonarQube server. */
     private String url;

--- a/src/main/js/common/api.js
+++ b/src/main/js/common/api.js
@@ -4,9 +4,10 @@
 
 import { getJSON, postJSON, post } from "sonar-request";
 
-// Function used to get current SonarQube Server version
+// Function used to check that the current SonarQube Server version is supported
+// Community Build reports 25.x / 26.x, Server reports 2025.x / 2026.x
 export function isCompatible() {
-  const COMPATIBILITY_PATTERN = /(25)(\.\d)(\.\d)*/;
+  const COMPATIBILITY_PATTERN = /^(20)?2[56]\./;
 
   return getJSON("/api/system/status").then(response => {
     return response.version.match(COMPATIBILITY_PATTERN) != null;

--- a/src/main/js/common/api.js
+++ b/src/main/js/common/api.js
@@ -66,8 +66,10 @@ function revokeToken(name) {
 }
 
 // Function used to create the plugin token
+// SonarQube checks expirationDate against its own UTC date, so the date is
+// computed in UTC and two days ahead to stay valid whatever the browser timezone
 function createToken(name) {
-  const expireDate = formatDate(new Date(Date.now() + 24 * 60 * 60 * 1000));
+  const expireDate = formatDate(new Date(Date.now() + 2 * 24 * 60 * 60 * 1000));
   return postJSON("/api/user_tokens/generate", { "name": name, "expirationDate": expireDate });
 }
 
@@ -78,11 +80,12 @@ function getUserName(login) {
   });
 }
 
+// Format a date as YYYY-MM-DD using its UTC fields
 function formatDate(date) {
     let d = new Date(date),
-        month = '' + (d.getMonth() + 1),
-        day = '' + d.getDate(),
-        year = d.getFullYear();
+        month = '' + (d.getUTCMonth() + 1),
+        day = '' + d.getUTCDate(),
+        year = d.getUTCFullYear();
 
     if (month.length < 2)
         month = '0' + month;
@@ -90,6 +93,19 @@ function formatDate(date) {
         day = '0' + day;
 
     return [year, month, day].join('-');
+}
+
+// Extract a readable message from a failed SonarQube request
+// sonar-request rejects with the raw Response, the message is in its JSON body
+function getErrorMessage(error) {
+  const fallback = "Unable to create the plugin token.";
+  if (error && typeof error.json === "function") {
+    return error.json().then(body => {
+      const messages = (body.errors || []).map(e => e.msg).filter(Boolean);
+      return messages.length > 0 ? messages.join(" ") : fallback;
+    }, () => fallback);
+  }
+  return Promise.resolve(error && error.message ? error.message : fallback);
 }
 
 // Macro function used to execute the whole plugin token process
@@ -104,6 +120,10 @@ export function initiatePluginToken() {
           author: userResponse
         }
       });
+    });
+  }).catch(error => {
+    return getErrorMessage(error).then(message => {
+      throw new Error(message);
     });
   });
 }

--- a/src/main/js/global_page/components/CnesReportApp.js
+++ b/src/main/js/global_page/components/CnesReportApp.js
@@ -10,6 +10,7 @@ import { getProjectsList, initiatePluginToken, getBranches, isCompatible } from 
 export default class CnesReportApp extends React.PureComponent {
     state = {
         loading: true,
+        error: "",
         projects: [],
         token: "",
         author: "",
@@ -67,9 +68,9 @@ export default class CnesReportApp extends React.PureComponent {
 
         // Initialize data in form
         initiatePluginToken().then(tokenInfo => {
-            getProjectsList().then(projects => {
+            return getProjectsList().then(projects => {
                 if (projects.length > 0) {
-                    getBranches(projects[0].key).then(branches => {
+                    return getBranches(projects[0].key).then(branches => {
                         this.setState({
                             loading: false,
                             projects: projects,
@@ -88,12 +89,18 @@ export default class CnesReportApp extends React.PureComponent {
                     });
                 }
             });
+        }).catch(error => {
+            this.setState({ loading: false, error: error.message });
         });
     }
 
     render() {
         if (this.state.loading) {
             return <div className="page page-limited"><p>Loading ...</p></div>;
+        }
+
+        if (this.state.error) {
+            return <div className="page page-limited"><p className="error-message">{this.state.error}</p></div>;
         }
 
         let projectsList = this.state.projects.length > 0

--- a/src/main/js/project_page/view/CnesReportProject.js
+++ b/src/main/js/project_page/view/CnesReportProject.js
@@ -10,6 +10,7 @@ import { initiatePluginToken, isCompatible } from "../../common/api";
 export default class CnesReportProject extends React.PureComponent {
     state = {
         loading: true,
+        error: "",
         token: "",
         author: "",
         languages: [{id: 'en_US', name: 'English'}, {id: 'fr_FR', name: 'French'}],
@@ -60,12 +61,18 @@ export default class CnesReportProject extends React.PureComponent {
         // Initialize data in form
         initiatePluginToken().then(tokenInfo => {
             this.setState({ token: tokenInfo.token, author: tokenInfo.author, loading: false });
+        }).catch(error => {
+            this.setState({ loading: false, error: error.message });
         });
     }
 
     render() {
         if (this.state.loading) {
             return <div className="page page-limited"><p>Loading ...</p></div>;
+        }
+
+        if (this.state.error) {
+            return <div className="page page-limited"><p className="error-message">{this.state.error}</p></div>;
         }
 
         const options = this.props.options;


### PR DESCRIPTION
## Proposed changes

SonarQube validates `expirationDate` on `api/user_tokens/generate` against its own UTC date and requires at least one day ahead. The plugin built the date from browser local time, one day ahead. In timezones behind UTC (US evenings, for example) the browser's date lags the server's, so the plugin sent today's date and got:

```
400: The minimum value for parameter expirationDate is <tomorrow>
```

The rejection was never handled, so the report page stayed on "Loading ...".

This PR:

- computes the expiration date from UTC fields, two days ahead, so it is in the future whatever the browser and server offsets
- switches `formatDate` to the `getUTC*` accessors (it is only used for the token date)
- catches a failed token generation on both the global and project pages and shows the server message in place of the form instead of hanging
- returns the nested project and branch promises on the global page so their failures reach the same handler
- accepts SonarQube 2025.x and 2026.x in the version check. Server reports year based versions such as `2026.1.0.x`, which neither the web UI pattern (25.x only) nor the standalone list (10.x, 25.x, 26.x) matched, so the unsupported banner showed on a supported server

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #411

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/cnescatlab/sonar-cnes-report/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] SonarCloud and CI tests pass with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules



